### PR TITLE
Fix run command issues

### DIFF
--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -146,7 +146,7 @@ if ( empty( $run_suites ) ) {
 } else {
 	// Run all the suites sequentially, stop at first error.
 	foreach ( $run_suites as $suite ) {
-		$command = array_merge( $base_command, $suite );
+		$command = array_merge( $base_command, (array) $suite );
 		$run_configuration[] = 'bash -c "' . implode( ' ', $command ) . '"';
 		$status = slic_realtime()( $run_configuration );
 		if ( $status !== 0 ) {

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -46,7 +46,8 @@ if ( $is_help ) {
 $using = slic_target_or_fail();
 echo light_cyan( "Using {$using}" . PHP_EOL );
 
-ensure_service_running( 'slic', codeception_dependencies() );
+$codeception_args = array_merge( [ 'run' ], $args( '...' ) );
+ensure_service_running( 'slic', codeception_dependencies( $codeception_args ) );
 
 setup_id();
 


### PR DESCRIPTION
This PR updates the `run.php` command file to ensure arguments will be passed
correctly and refactors the `composer` command to avoid version queries from running
in a pool or requiring sub-module build.

