### PR TITLE
fix(containers/slic) scaffold a free-for-all /cache directory

### DIFF
--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -68,6 +68,9 @@ COPY ./bashrc_scripts.sh /home/slic/bashrc_scripts.sh
 
 RUN chown -R slic:slic $NVM_DIR
 
+# Create a /cache directory any user will be able to read, write and execute from.
+RUN mkdir /cache && chmod a+rwx /cache
+
 COPY ./slic-entrypoint.sh /usr/local/bin/slic-entrypoint.sh
 RUN chmod a+x /usr/local/bin/slic-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/slic-entrypoint.sh"]

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -6,7 +6,7 @@ networks:
   slic:
 
 volumes:
-  function-mocker-cache: # @todo move to file cache
+  function-mocker-cache:
 
 services:
 
@@ -149,7 +149,7 @@ services:
       # In some plugins we use function-mocker and set it up to cache in `/tmp/function-mocker`.
       # To avoid a long re-caching on each run, let's cache in a docker volume, caching on the host
       # filesystem would be a worse cure than the disease.
-      # The volume is bound to the `a+rwx` directory the `codeception` image provides to avoid file mode issues.
+      # The volume is bound to the `a+rwx` directory the `slic` image provides to avoid file mode issues.
       - function-mocker-cache:/cache
       - ${COMPOSER_CACHE_DIR}:${COMPOSER_CACHE_DIR}
       # Scripts volume


### PR DESCRIPTION
Some plugins will use the `/cache` directory in the `slic` container to
store test-related information in it.

This PR ensures the directory is there.j
