### PR TITLE
Add workflow to build and publish `slic` image

### DIFF
--- a/.github/workflows/publish-slic-image.yml
+++ b/.github/workflows/publish-slic-image.yml
@@ -9,7 +9,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
+  publish-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish-slic-image.yml
+++ b/.github/workflows/publish-slic-image.yml
@@ -1,0 +1,55 @@
+name: Publish slic Docker image
+
+on:
+  push:
+  release:
+    types: [published]
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge,branch=main
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{raw}}
+
+      - name: Build and push slic Docker image
+        uses: docker/build-push-action@v3.1.1
+        continue-on-error: true
+        with:
+          context: containers/slic
+          file: containers/slic/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This publishes the `slic` container to the GitHub packages registry.