### PR TITLE
Update the `slic-stack.yml` to use the `slic` and `slic-wordpress` Docker images

### DIFF
--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -98,10 +98,7 @@ services:
       - "wordpress.test:172.${SLIC_TEST_SUBNET:-28}.1.1"
 
   slic:
-    image: the-events-calendar/slic:${SLIC_VERSION}
-    build:
-      context: ./containers/slic
-      dockerfile: Dockerfile
+    image: ghcr.io/stellarwp/slic:${SLIC_VERSION}
     networks:
       - slic
     user: "${SLIC_UID:-}:${SLIC_GID:-}"

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -28,14 +28,7 @@ services:
       - "${SLIC_REDIS_LOCALHOST_PORT:-8379}:6379"
 
   wordpress:
-    image: the-events-calendar/slic_wordpress:${SLIC_VERSION}
-    build:
-      context: containers/wordpress
-      # By default, build the version of Docker that does not include XDebug.
-      dockerfile: Dockerfile
-      args:
-        # Fix the version of the WordPress image to avoid issues w/ out-of-date database dumps.
-        WORDPRESS_IMAGE_VERSION: wordpress:5.9.3-php7.4-apache
+    image: ghcr.io/stellarwp/slic-wordpress:${SLIC_VERSION}
     networks:
       - slic
     depends_on:


### PR DESCRIPTION
Now that we have GitHub actions building our images, let's use them in the stack.

🎥 https://d.pr/v/IVHchU