### PR TITLE
Generate a Docker image for the WordPress container as well

### DIFF
--- a/.github/workflows/publish-slic-wordpress-image.yml
+++ b/.github/workflows/publish-slic-wordpress-image.yml
@@ -1,0 +1,56 @@
+name: Publish slic-wordpress Docker image
+
+on:
+  push:
+  release:
+    types: [published]
+
+env:
+  IMAGE_NAME: ${{ github.repository }}-wordpress
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge,branch=main
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{raw}}
+
+      - name: Build and push slic-wordpress Docker image
+        uses: docker/build-push-action@v3.1.1
+        continue-on-error: true
+        with:
+          context: containers/wordpress
+          file: containers/wordpress/Dockerfile
+          push: true
+          pull: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -1,6 +1,6 @@
 ARG WORDPRESS_IMAGE_VERSION=wordpress/apache
 
-FROM ${WORDPRESS_IMAGE_VERSION}
+FROM wordpress:6.0.2-php7.4-apache
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod a+x /usr/local/bin/install-php-extensions && install-php-extensions xdebug
 COPY xdebug-on.sh /usr/local/bin/xdebug-on


### PR DESCRIPTION
This generates a second Docker image to speed slic up even more.