### PR TITLE
Check for curl_init() errors via boolean

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- PHP 8.0+ compatibility fix for WordPress zip downloads.
 
 ## [1.0.5] - 2022-09-02
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -569,8 +569,9 @@ function download_file( $source_url, $dest_file, $verify_host = true ) {
 
 	$curl_handle = curl_init();
 
-	if ( ! is_resource( $curl_handle ) ) {
+	if ( $curl_handle === false ) {
 		fclose( $file_handle );
+		unlink( $dest_file );
 
 		return false;
 	}


### PR DESCRIPTION
Rather than checking for a successful `curl_init()`, let's check for a failure that is compatible with PHP 8.x and lower.

Addresses #113