### PR TITLE
Prevent looping over the same test suite when doing `slic run`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - PHP 8.0+ compatibility fix for WordPress zip downloads.
+- Prevent looping over the same test suite when executing `slic run`. [#118]
 
 ## [1.0.5] - 2022-09-02
 

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -121,7 +121,7 @@ switch ( $available_configs_mask ) {
 		break;
 }
 // Add slic configuration file, if existing.
-$run_configuration = [
+$base_configuration = [
 	'exec',
 	'--user',
 	sprintf( '"%s:%s"', getenv( 'SLIC_UID' ), getenv( 'SLIC_GID' ) ),
@@ -141,15 +141,17 @@ if ( empty( $run_args ) ) {
 // Finally run the command.
 if ( empty( $run_suites ) ) {
 	// Run the command as per user input.
-	$command = array_merge( $base_command, $run_args );
-	$run_configuration[] = 'bash -c "' . implode( ' ', $command ) . '"';
-	$status = slic_realtime()( $run_configuration );
+	$command              = array_merge( $base_command, $run_args );
+	$base_configuration[] = 'bash -c "' . implode( ' ', $command ) . '"';
+	$status               = slic_realtime()( $base_configuration );
 } else {
 	// Run all the suites sequentially, stop at first error.
 	foreach ( $run_suites as $suite ) {
-		$command = array_merge( $base_command, (array) $suite );
+		$command             = array_merge( $base_command, (array) $suite );
+		$run_configuration   = $base_configuration;
 		$run_configuration[] = 'bash -c "' . implode( ' ', $command ) . '"';
-		$status = slic_realtime()( $run_configuration );
+		$status              = slic_realtime()( $run_configuration );
+
 		if ( $status !== 0 ) {
 			exit( $status );
 		}


### PR DESCRIPTION
The `slic run` command - when executed without arguments - was inaccurately building the docker command by continuously adding subsequent suite execution commands rather than constructing a new docker command.

@bordoni let me know about this bug in Slack.

:movie_camera: https://d.pr/v/CCqn5X

Resolves: #118