### PR TITLE
Set the composer-cache directory correctly

### DIFF
--- a/.env.slic
+++ b/.env.slic
@@ -75,4 +75,4 @@ SLIC_DB_LOCALHOST_PORT=9906
 WORDPRESS_HTTP_PORT=8888
 
 # Directory the host machine's cache directory will be mapped to.
-COMPOSER_CACHE_DIR=
+COMPOSER_CACHE_DIR=./.cache

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix - Set the Composer cache directory default location correctly.
+
 ## [1.1.0] - 2022-09-05
 
 ### Changed

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -70,6 +70,7 @@ RUN chown -R slic:slic $NVM_DIR
 
 # Create a /cache directory any user will be able to read, write and execute from.
 RUN mkdir /cache && chmod a+rwx /cache
+RUN mkdir /composer-cache && chmod a+rwx /composer-cache
 
 COPY ./slic-entrypoint.sh /usr/local/bin/slic-entrypoint.sh
 RUN chmod a+x /usr/local/bin/slic-entrypoint.sh

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -47,7 +47,7 @@ services:
       # The port, in the container, is not the default `80` to allow non root users to bind (listen) to it.
       - "${WORDPRESS_HTTP_PORT:-8888}:80"
     environment:
-      COMPOSER_CACHE_DIR: ${COMPOSER_CACHE_DIR:-}
+      COMPOSER_CACHE_DIR: "/composer-cache"
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
       # This db is created by the db container at startup, no need to create it.
@@ -81,7 +81,7 @@ services:
       - ${SLIC_WP_DIR}:/var/www/html:cached
       - ${SLIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins:cached
       - ${SLIC_THEMES_DIR}:/var/www/html/wp-content/themes:cached
-      - ${COMPOSER_CACHE_DIR}:${COMPOSER_CACHE_DIR}:cached
+      - ${COMPOSER_CACHE_DIR:-./.cache}:/composer-cache:cached
 
   chrome:
     image: ${SLIC_CHROME_CONTAINER:-selenium/standalone-chrome:3.141.59-oxygen}
@@ -96,7 +96,7 @@ services:
       - slic
     user: "${SLIC_UID:-}:${SLIC_GID:-}"
     environment:
-      COMPOSER_CACHE_DIR: ${COMPOSER_CACHE_DIR:-}
+      COMPOSER_CACHE_DIR: "/composer-cache"
       # Set these values to allow the container to look wordpress up.
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
@@ -141,7 +141,7 @@ services:
       # filesystem would be a worse cure than the disease.
       # The volume is bound to the `a+rwx` directory the `slic` image provides to avoid file mode issues.
       - function-mocker-cache:/cache
-      - ${COMPOSER_CACHE_DIR}:${COMPOSER_CACHE_DIR}
+      - ${COMPOSER_CACHE_DIR:-./.cache}:/composer-cache
       # Scripts volume
       - ${SLIC_SCRIPTS}:/slic-scripts:cached
 

--- a/src/slic.php
+++ b/src/slic.php
@@ -287,6 +287,7 @@ function setup_slic_env( $root_dir, $reset = false ) {
 	putenv( 'SLIC_CACHE=' . cache() );
 
 	if ( empty( getenv( 'COMPOSER_CACHE_DIR' ) ) ) {
+		ensure_dir( root( '.cache' ) );
 		putenv( 'COMPOSER_CACHE_DIR=' . cache( '/composer' ) );
 	}
 


### PR DESCRIPTION
This ensures that there is always a `/composer-cache` directory in the container and defaults to a `.cache/` directory in the `slic` project, but allows for overriding elsewhere.

Previously, the mounted volumes and composer cache dir env variable were set poorly when `slic composer-cache set <dir>` _wasn't run_, causing `files/`, `vcs/`, and `repo/` directories to appear on the filesystem after running `slic composer install`.

🎥 https://d.pr/v/5nybHy

Fixes: #78