### PR TITLE
Add the PHP version to `slic info`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tweak - Add `SLIC_PHP_VERSION` to `slic info`.
+- Tweak - Make the `Valid Targets:` output a bit less readable during `slic info` in favor of keeping the env values visible.
+
 ## [1.1.0] - 2022-09-05
 
 ### Changed

--- a/src/slic.php
+++ b/src/slic.php
@@ -667,6 +667,7 @@ function slic_info() {
 		'COMPOSER_CACHE_DIR',
 		'CONTINUOUS_INTEGRATION',
 		'GITHUB_ACTION',
+		'SLIC_PHP_VERSION',
 		'SLIC_CURRENT_PROJECT',
 		'SLIC_CURRENT_PROJECT_RELATIVE_PATH',
 		'SLIC_CURRENT_PROJECT_SUBDIR',
@@ -718,7 +719,8 @@ function slic_info() {
 
 	echo PHP_EOL;
 	echo colorize( "<yellow>Valid Targets:</yellow>" );
-	echo get_valid_targets( false );
+	$targets = get_valid_targets( true );
+	echo PHP_EOL . implode( ', ', $targets );
 }
 
 /**


### PR DESCRIPTION
This is a small tweak that adds the env var that holds the PHP version number to the `slic info` output. Additionally, this makes the `Valid Targets:` output a bit less readable during `slic info` in favor of keeping the env values visible.

![Screenshot 2022-09-05 125341](https://user-images.githubusercontent.com/430385/188492030-7f243dd6-0d38-4782-975c-5df2f3ae7402.png)
