### PR TITLE
Add the `slic exec` command for bash command execution in stack

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Feature - Added the `slic exec` command that allows bash command execution within the stack. [#31]
+
 ## [1.1.0] - 2022-09-05
 
 ### Changed

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $cli_name = 'slic';
 const CLI_VERSION = '1.1.1';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
-if ( in_array( '-q', $argv, true ) ) {
+if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {
     // Remove the `-q` flag from the global array of arguments to leave the rest of the commands unchanged.
 	unset( $argv[ array_search( '-q', $argv ) ] );
 	$argv = array_values( $argv );
@@ -88,6 +88,7 @@ $help_advanced_message_template = <<< HELP
   <light_cyan>config</light_cyan>         Prints the stack configuration as interpolated from the environment.
   <light_cyan>debug</light_cyan>          Activates or deactivates {$cli_name} debug output or returns the current debug status.
   <light_cyan>down</light_cyan>           Tears down the stack; alias of `stop`.
+  <light_cyan>exec</light_cyan>           Runs a bash command in the stack.
   <light_cyan>group</light_cyan>          Create or remove group of targets for the current plugins directory.
   <light_cyan>host-ip</light_cyan>        Returns the IP Address of the host machine from the container perspective.
   <light_cyan>init</light_cyan>           Initializes a plugin for use in slic.
@@ -174,6 +175,7 @@ switch ( $subcommand ) {
 	case 'config':
 	case 'debug':
 	case 'down':
+	case 'exec':
 	case 'here':
 	case 'host-ip':
 	case 'info':

--- a/src/commands/exec.php
+++ b/src/commands/exec.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Handles a request to run a bash command using the `slic` service.
+ *
+ * @var bool     $is_help  Whether we're handling an `help` request on this command or not.
+ * @var \Closure $args     The argument map closure, as produced by the `args` function.
+ * @var string   $cli_name The current name of the main CLI command, e.g. `slic`.
+ */
+
+namespace StellarWP\Slic;
+
+if ( $is_help ) {
+	$help = <<< HELP
+	SUMMARY:
+
+		Runs a bash command in the stack.
+
+	USAGE:
+
+		<yellow>{$cli_name} {$subcommand} "<commands>"</yellow>
+
+	EXAMPLES:
+
+		<light_cyan>{$cli_name} {$subcommand} "whoami"</light_cyan>
+		Runs the whoami command in the stack.
+
+	HELP;
+
+	echo colorize( $help );
+	return;
+}
+
+$using = slic_target_or_fail();
+
+ensure_service_running( 'slic' );
+
+setup_id();
+$exec_args = $args( '...' );
+
+if ( empty( $exec_args ) ) {
+	echo colorize( '<red>Please specify a bash command to execute.</red> Type <light_cyan>slic help exec</light_cyan> for more info.' . PHP_EOL );
+	exit( 1 );
+}
+
+$exec_command = trim( $exec_args[0] );
+
+ob_start();
+$status = slic_realtime()(
+	array_merge(
+		[
+			'exec',
+			'--user',
+			sprintf( '"%s:%s"', getenv( 'SLIC_UID' ), getenv( 'SLIC_GID' ) ),
+			'--workdir',
+			escapeshellarg( get_project_container_path() ),
+			'slic',
+			'bash -c',
+		],
+		[ $exec_command ]
+	)
+);
+$output = ob_get_clean();
+
+echo trim( $output ) . PHP_EOL;
+
+// If there is a status other than 0, we have an error. Bail.
+if ( $status ) {
+	exit( $status );
+}
+
+exit( $status );
+


### PR DESCRIPTION
This adds a `slic exec` command that allows for bash command execution via `docker-compose exec <blahblah> bash -c`. When running the `slic exec` command, the header for slic is suppressed.

:movie_camera: https://d.pr/v/8IiSF2
Resolves: #31