### PR TITLE
Better management of on-up callbacks

### DIFF
--- a/slic.php
+++ b/slic.php
@@ -16,6 +16,8 @@ require_once __DIR__ . '/src/env.php';
 require_once __DIR__ . '/src/codeception.php';
 require_once __DIR__ . '/src/commands.php';
 
+require_once __DIR__ . '/src/classes/Callback_Stack.php';
+
 use function StellarWP\Slic\args;
 use function StellarWP\Slic\cli_header;
 use function StellarWP\Slic\colorize;

--- a/src/classes/Callback_Stack.php
+++ b/src/classes/Callback_Stack.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace StellarWP\Slic;
+
+use Closure;
+use ReflectionFunction;
+
+class Callback_Stack {
+	/**
+	 * A set of callbacks accumulated in the stack so far, by
+	 * priority.
+	 *
+	 * @var array<string,callable>
+	 */
+	private $callbacks = [];
+
+	public function call(): void {
+		foreach ( $this->callbacks as $callback ) {
+			$callback();
+		}
+	}
+
+	/**
+	 * Add a callback to the stack, with a specified priority.
+	 *
+	 * @param string   $callback_id The callback ID.
+	 * @param callable $callback    The callback to add.
+	 *
+	 * @return void The callback is added to the stack.
+	 */
+	public function add( string $callback_id, callable $callback ): void {
+		$this->callbacks[ $callback_id ] = $callback;
+	}
+}

--- a/src/commands/airplane-mode.php
+++ b/src/commands/airplane-mode.php
@@ -40,7 +40,7 @@ $toggle = args( [ 'toggle' ], $args( '...' ), 0 )( 'toggle', 'on' );
 $activate = $toggle === 'on';
 
 setup_id();
-ensure_service_running( 'slic' );
+ensure_service_running( 'slic', [], true );
 ensure_wordpress_ready();
 
 $ensure_airplane_mode_plugin = static function () {

--- a/src/commands/cache.php
+++ b/src/commands/cache.php
@@ -42,7 +42,7 @@ $cache_args = args( [ 'toggle' ], $args( '...' ), 0 );
 $toggle = $cache_args( 'toggle', 'status' );
 
 setup_id();
-ensure_services_running( [ 'wordpress', 'slic' ] );
+ensure_services_running( [ 'wordpress', 'slic' ], true );
 ensure_wordpress_ready();
 
 // Ensure the plugin is installed.

--- a/src/commands/cc.php
+++ b/src/commands/cc.php
@@ -38,7 +38,7 @@ echo light_cyan( "Using {$using}" . PHP_EOL );
 
 setup_id();
 $codeception_args = $args( '...' );
-ensure_service_running( 'slic', codeception_dependencies( $codeception_args ) );
+ensure_service_running( 'slic', codeception_dependencies( $codeception_args ), tru );
 
 $codeception_config = '';
 if ( file_exists( get_project_local_path() . '/codeception.slic.yml' ) ) {

--- a/src/commands/cli.php
+++ b/src/commands/cli.php
@@ -34,7 +34,7 @@ if ( $is_help ) {
 }
 
 setup_id();
-ensure_services_running( [ 'slic', 'db' ] );
+ensure_services_running( [ 'slic', 'db' ], true );
 ensure_wordpress_ready();
 
 // Runs a wp-cli command in the stack, using the `cli` service.

--- a/src/commands/composer.php
+++ b/src/commands/composer.php
@@ -43,7 +43,7 @@ if ( $is_help ) {
 $using = slic_target_or_fail();
 echo light_cyan( "Using {$using}" . PHP_EOL );
 
-ensure_service_running( 'slic' );
+ensure_service_running( 'slic', [], true );
 
 $default_version = 1;
 $command = $args( '...' );

--- a/src/commands/exec.php
+++ b/src/commands/exec.php
@@ -32,7 +32,7 @@ if ( $is_help ) {
 
 $using = slic_target_or_fail();
 
-ensure_service_running( 'slic' );
+ensure_service_running( 'slic', [], true );
 
 setup_id();
 $exec_args = $args( '...' );

--- a/src/commands/logs.php
+++ b/src/commands/logs.php
@@ -24,6 +24,6 @@ if ( $is_help ) {
 	return;
 }
 
-ensure_service_running( 'slic' );
+ensure_service_running( 'slic', [], true );
 
 slic_realtime()( [ 'logs', '--follow' ] );

--- a/src/commands/mysql.php
+++ b/src/commands/mysql.php
@@ -24,7 +24,7 @@ if ( $is_help ) {
 	return;
 }
 
-ensure_service_running( 'db' );
+ensure_service_running( 'db', [], true );
 
 setup_id();
 

--- a/src/commands/npm.php
+++ b/src/commands/npm.php
@@ -27,7 +27,7 @@ if ( $is_help ) {
 $using = slic_target_or_fail();
 echo light_cyan( "Using {$using}" . PHP_EOL );
 
-ensure_service_running( 'slic' );
+ensure_service_running( 'slic', [], true );
 
 $command = $args( '...' );
 if ( '--pretty' === end( $command ) ) {

--- a/src/commands/phpcbf.php
+++ b/src/commands/phpcbf.php
@@ -29,7 +29,7 @@ if ( $is_help ) {
 $using = slic_target_or_fail();
 echo light_cyan( "Using {$using}" . PHP_EOL );
 
-ensure_service_running( 'slic' );
+ensure_service_running( 'slic', [], true );
 
 setup_id();
 $phpcbf_args = $args( '...' );

--- a/src/commands/phpcs.php
+++ b/src/commands/phpcs.php
@@ -29,7 +29,7 @@ if ( $is_help ) {
 $using = slic_target_or_fail();
 echo light_cyan( "Using {$using}" . PHP_EOL );
 
-ensure_service_running( 'slic' );
+ensure_service_running( 'slic', [], true );
 
 setup_id();
 $phpcs_args = $args( '...' );

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -47,7 +47,7 @@ $using = slic_target_or_fail();
 echo light_cyan( "Using {$using}" . PHP_EOL );
 
 $codeception_args = array_merge( [ 'run' ], $args( '...' ) );
-ensure_service_running( 'slic', codeception_dependencies( $codeception_args ) );
+ensure_service_running( 'slic', codeception_dependencies( $codeception_args ), true );
 
 setup_id();
 

--- a/src/commands/shell.php
+++ b/src/commands/shell.php
@@ -33,7 +33,7 @@ $service = $service_args( 'service', 'slic' );
 $using = slic_target_or_fail();
 echo light_cyan( "Using {$using}" . PHP_EOL );
 
-ensure_services_running( [ 'wordpress', 'slic' ] );
+ensure_services_running( [ 'wordpress', 'slic' ], true );
 
 setup_id();
 

--- a/src/commands/site-cli.php
+++ b/src/commands/site-cli.php
@@ -31,7 +31,7 @@ if ( $is_help ) {
 
 setup_id();
 
-ensure_services_running( [ 'wordpress', 'slic' ] );
+ensure_services_running( [ 'wordpress', 'slic' ], true );
 ensure_wordpress_ready();
 
 $command = $args( '...' );

--- a/src/commands/ssh.php
+++ b/src/commands/ssh.php
@@ -40,7 +40,7 @@ if ( $is_help ) {
 $service_args = args( [ 'service', '...' ], $args( '...' ), 0 );
 $service = $service_args( 'service', 'slic' );
 
-ensure_service_running( $service );
+ensure_service_running( $service, [], true );
 
 $command = sprintf( 'docker exec -it --user "%d:%d" --workdir %s %s bash',
 	getenv( 'SLIC_UID' ),

--- a/src/commands/start.php
+++ b/src/commands/start.php
@@ -32,7 +32,7 @@ if ( ! $service ) {
 	exit;
 }
 
-$exit_status = ensure_service_running( $service );
+$exit_status = ensure_service_running( $service, [], true );
 
 if ( $exit_status !== 0 ) {
 	echo colorize( PHP_EOL . "❌ <red>{$service} failed to start.</red>" . PHP_EOL );

--- a/src/services.php
+++ b/src/services.php
@@ -24,7 +24,7 @@ function stack_schema() {
 	require_once __DIR__ . '/../includes/Spyc/Spyc.php';
 
 	$schemas = [];
-	$stack   = slic_stack_array( true );
+	$stack = slic_stack_array( true );
 	foreach ( $stack as $file ) {
 		if ( ! is_readable( $file ) ) {
 			echo magenta( "File $file cannot be found or is not readable." );
@@ -65,6 +65,7 @@ function get_services() {
 	$services = services_schema();
 	$services = array_keys( $services );
 	sort( $services );
+
 	return $services;
 }
 
@@ -79,7 +80,7 @@ function get_services() {
  * @return array<string> A list of the service dependencies; empty if the service has no
  *                       dependencies.
  */
-function service_dependencies( $service ) {
+function service_dependencies( string $service ) {
 	$services_schema = services_schema();
 	$service_links = isset( $services_schema[ $service ]['links'] ) ? $services_schema[ $service ]['links'] : [];
 	$service_dependencies = isset( $services_schema[ $service ]['depends_on'] ) ? $services_schema[ $service ]['depends_on'] : [];
@@ -96,7 +97,7 @@ function service_dependencies( $service ) {
  *
  * @return false Whether the specified service requires at least one of the dependencies or not.
  */
-function service_requires( $service, ...$dependencies ) {
+function service_requires( string $service, ...$dependencies ) {
 	if ( empty( $dependencies ) ) {
 		return false;
 	}
@@ -109,26 +110,32 @@ function service_requires( $service, ...$dependencies ) {
  *
  * @param string $service The service to check.
  *
- * @return Closure A closure that should be called after the service is
- *                 up and running, to finish setting it up.
+ * @return void The service readiness is ensured; if required
+ *              by the service, a callback that should be called
+ *              after the service is ready is registered in the
+ *              Services callback stack.
  */
-function ensure_service_ready( $service ) {
-	$noop = static function(){};
+function ensure_service_ready( string $service ): void {
+	$propagate_wordpress_address = static function () {
+		propagate_ip_address_of_to(
+			[ 'wordpress' ],
+			[ 'wordpress', 'slic', 'chrome' ],
+			[ 'wordpress' => 'wordpress.test' ]
+		);
+	};
 
 	switch ( $service ) {
 		case 'wordpress':
 			ensure_wordpress_ready();
 			service_up_notify( 'wordpress' );
-
-			return static function () {
-				propagate_ip_address_of_to(
-					[ 'wordpress' ],
-					[ 'wordpress', 'slic', 'chrome' ],
-					[ 'wordpress' => 'wordpress.test' ]
-				);
-			};
+			services_callback_stack()->add( 'propagate_wp_address', $propagate_wordpress_address );
+			break;
+		case 'slic':
+		case 'chrome':
+			services_callback_stack()->add( 'propagate_wp_address', $propagate_wordpress_address );
+			break;
 		default:
-			return $noop;
+			break;
 	}
 }
 
@@ -138,12 +145,10 @@ function ensure_service_ready( $service ) {
  *
  * @param string $service The service to ensure the dependencies for.
  *
- * @return Closure A closure that should be called after the service is
- *                 up and running to finish setting it up in respect to
- *                 its dependencies.
+ * @return void
  */
-function ensure_service_dependencies( $service ) {
-	return ensure_services_running( service_dependencies( $service ) );
+function ensure_service_dependencies( string $service ): void {
+	ensure_services_running( service_dependencies( $service ) );
 }
 
 /**
@@ -152,11 +157,13 @@ function ensure_service_dependencies( $service ) {
  *
  * @param array<string> $services A list of services to ensure
  *                                are running.
+ * @param bool $call_on_up Whether to call the `on_up` callbacks for the
+ *                         started services or not.
  *
- * @return Closure A closure that should be called after all
- *                 services are up to complete a service setup.
+ * @return void On-up callbacks will be registered on the global
+ *              callback stack.
  */
-function ensure_services_running( array $services ) {
+function ensure_services_running( array $services, bool $call_on_up = false  ): void {
 	// Impose an order to make sure dependencies are optimized.
 	$order = [ 'db', 'redis', 'chrome', 'slic', 'wordpress' ];
 	usort( $services, static function ( $a, $b ) use ( $order ) {
@@ -165,18 +172,9 @@ function ensure_services_running( array $services ) {
 
 		return $a_index <=> $b_index;
 	} );
-	$on_up = [];
 	foreach ( $services as $service ) {
-		$service_on_up = [];
-		ensure_service_running( $service, [], $service_on_up );
-		$on_up = array_merge( $on_up, $service_on_up );
+		ensure_service_running( $service );
 	}
-
-	return static function () use ( $on_up ) {
-		foreach ( $on_up as $then ) {
-			$then();
-		}
-	};
 }
 
 /**
@@ -186,7 +184,7 @@ function ensure_services_running( array $services ) {
  *
  * @return bool Whether a service is running or not.
  */
-function service_running( $service ) {
+function service_running( string $service ) {
 	$ps = slic_process()( [ 'ps', '--services', '--filter', '"status=running"' ] );
 	$ps_status = $ps( 'status' );
 
@@ -220,8 +218,8 @@ function quietly_tear_down_stack() {
  *
  * @return string|null The service container ID if found, `null` otherwise.
  */
-function get_service_id( $service ) {
-	$root    = root();
+function get_service_id( string $service ) {
+	$root = root();
 	$command = "docker ps -f label=com.docker.compose.project.working_dir='$root' " .
 	           "-f label=com.docker.compose.service=$service --format '{{.ID}}'";
 	debug( "Executing command: $command" . PHP_EOL );
@@ -238,7 +236,7 @@ function get_service_id( $service ) {
  * @return string|null The service IP address if the service is up and the IP address
  *                     could be found, `null` otherwise.
  */
-function get_service_ip_address( $service_id ) {
+function get_service_ip_address( string $service_id ) {
 	$command = "docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $service_id";
 	debug( "Executing command: $command" . PHP_EOL );
 	exec( $command, $output, $status );
@@ -263,7 +261,7 @@ function get_service_ip_address( $service_id ) {
  * @return true To indicate the operation was completed correctly, the function
  *              will `exit` with an error, otherwise.
  */
-function add_hosts_to_service( $service_id, array $hosts ) {
+function add_hosts_to_service( string $service_id, array $hosts ) {
 	// Read the current contents of the `/etc/hosts` file.
 	$read_command = "docker exec -u '0:0' $service_id bash -c 'cat /etc/hosts'";
 	debug( "Executing command: $read_command" . PHP_EOL );
@@ -306,10 +304,10 @@ function add_hosts_to_service( $service_id, array $hosts ) {
  * Updates the `/etc/hosts` file of a list of services to include the IP address of another set of
  * services.
  *
- * @param array<string> $of_services The list of services whose IP address should be propagated.
- * @param array<string> $to_services The list of services whose `/etc/hosts` file should be updated
- *                                   to include the IP addresses to hastname mappings of the previous
- *                                   list.
+ * @param array<string>        $of_services  The list of services whose IP address should be propagated.
+ * @param array<string>        $to_services  The list of services whose `/etc/hosts` file should be updated
+ *                                           to include the IP addresses to hastname mappings of the previous
+ *                                           list.
  * @param array<string,string> $hostname_map A map from service names to the hostnames they should be
  *                                           mapped to.
  *
@@ -352,34 +350,35 @@ function propagate_ip_address_of_to( array $of_services, array $to_services, arr
  * Ensures a service is running by ensuring all its pre-conditions and services
  * it depends on.
  *
- * @param string $service The name of the service to ensure running, e.g., `wordpress`.
+ * @param string        $service      The name of the service to ensure running, e.g., `wordpress`.
  * @param array<string> $dependencies The list of services that should be running.
- * @param array<callable> $on_up If provided, the services and dependencies "on up" callbacks
- *                               will not be immediately executed, but instead will be added to
- *                               this list.
+ * @param bool          $call_on_up   Whether to call the `on_up` function of the service(s) being
+ *                                    started or not.
  *
  * @return int The exit status of the command that will ensure the service is running;
  *             following UNIX convention, a `0` indicates a success, any other value indicates a
  *             failure.
  */
-function ensure_service_running( $service, array $dependencies = null, array &$on_up = null  ) {
+function ensure_service_running( string $service, array $dependencies = null, bool $call_on_up = false ): int {
 	if ( empty( $dependencies ) && service_running( $service ) ) {
 		service_up_notify( $service );
+
 		return 0;
 	}
 
 	if ( empty( $dependencies ) ) {
-		$dependencies_on_up = ensure_service_dependencies( $service );
+		ensure_service_dependencies( $service );
 	} else {
-		$dependencies_on_up = ensure_services_running( $dependencies );
+		ensure_services_running( $dependencies );
 	}
 
 	if ( service_running( $service ) ) {
 		service_up_notify( $service );
+
 		return 0;
 	}
 
-	$own_on_up = ensure_service_ready( $service );
+	ensure_service_ready( $service );
 
 	$up_status = slic_realtime()( [ 'up', '-d', $service ] );
 	service_running( $service );
@@ -388,11 +387,8 @@ function ensure_service_running( $service, array $dependencies = null, array &$o
 		return $up_status;
 	}
 
-	if ( is_array( $on_up ) ) {
-		array_push( $on_up, $dependencies_on_up, $own_on_up );
-	} else {
-		$dependencies_on_up();
-		$own_on_up();
+	if ( $call_on_up ) {
+		services_callback_stack()->call();
 	}
 
 	service_up_notify( $service );
@@ -405,11 +401,26 @@ function ensure_service_running( $service, array $dependencies = null, array &$o
  *
  * @param string $service
  */
-function service_up_notify( string $service ) : void {
+function service_up_notify( string $service ): void {
 	switch ( $service ) {
 		case 'wordpress':
 			echo colorize( PHP_EOL . "Your WordPress site is reachable at: <yellow>http://localhost:" . getenv( 'WORDPRESS_HTTP_PORT' ) . "</yellow>" . PHP_EOL );
 		default:
 			return;
 	}
+}
+
+/**
+ * Returns the singleton instance of the Services callback stack.
+ *
+ * @return Callback_Stack The singleton instance of the Services callback stack.
+ */
+function services_callback_stack(): Callback_Stack {
+	static $callback_stack;
+
+	if ( ! $callback_stack instanceof Callback_Stack ) {
+		$callback_stack = new Callback_Stack();
+	}
+
+	return $callback_stack;
 }

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -43,7 +43,7 @@ HTACCESS;
  *
  * @return bool
  */
-function dir_has_local_config( $dir ) {
+function dir_has_local_config( $dir ): bool {
 	return file_exists( "{$dir}/local-config.php" );
 }
 
@@ -54,7 +54,7 @@ function dir_has_local_config( $dir ) {
  *
  * @return bool
  */
-function dir_has_wp_config( $dir ) {
+function dir_has_wp_config( $dir ): bool {
 	return file_exists( "{$dir}/wp-config.php" );
 }
 
@@ -64,7 +64,7 @@ function dir_has_wp_config( $dir ) {
  * @return array<string,SplFileInfo> A map of each directory in the relevant plugins or themes directory to the
  *                                   corresponding file information.
  */
-function wp_content_dir_list( $content_type = 'plugins' ) {
+function wp_content_dir_list( $content_type = 'plugins' ): array {
 	$function = "\\StellarWP\\Slic\\slic_{$content_type}_dir";
 	$path     = $function();
 
@@ -101,7 +101,7 @@ function wp_content_dir_list( $content_type = 'plugins' ) {
  *
  * @return array<string> Allowed subdirectories for use.
  */
-function get_allowed_use_subdirectories() {
+function get_allowed_use_subdirectories(): array {
 	return [ 'common' ];
 }
 
@@ -116,7 +116,7 @@ function get_allowed_use_subdirectories() {
  *
  * @return bool Always `true` to indicate files are in place.
  */
-function ensure_wordpress_files( $version = null ) {
+function ensure_wordpress_files( $version = null ): bool {
 	// By default, download the latest WordPress version.
 	$source_url = 'https://wordpress.org/latest.zip';
 
@@ -210,7 +210,7 @@ function ensure_wordpress_files( $version = null ) {
  * @return bool Always `true` to indicate WordPress
  *              is set up correctly.
  */
-function ensure_wordpress_configured() {
+function ensure_wordpress_configured(): bool {
 	$wp_root_dir    = getenv( 'SLIC_WP_DIR' );
 	$wp_config_file = $wp_root_dir . '/wp-config.php';
 
@@ -301,7 +301,7 @@ CONFIG_EXTRAS;
  * @return bool Always `true` to indicate WordPress is
  *              correctly installed.
  */
-function ensure_wordpress_installed() {
+function ensure_wordpress_installed(): bool {
 	setup_slic_env( root() );
 
 	// Bring up the database.
@@ -393,7 +393,7 @@ function ensure_wordpress_installed() {
  * @return string The current latest version, or `1.0.0` if the information
  *                could not be retrieved.
  */
-function get_wordpress_latest_version() {
+function get_wordpress_latest_version(): string {
 	static $current_latest_version;
 
 	if ( $current_latest_version !== null ) {
@@ -446,7 +446,7 @@ function get_wordpress_latest_version() {
  *
  * @return bool Always `true` to indicate success.
  */
-function ensure_wordpress_ready( $version = null ) {
+function ensure_wordpress_ready( string $version = null ): bool {
 	ensure_wordpress_files( $version );
 	ensure_wordpress_configured();
 	ensure_wordpress_installed();


### PR DESCRIPTION
The purpose of this PR is to simplify the management of the callbacks that should be called after services are up.
Currently: propagate the IP address of the WordPress container to itself, the `slic` and the `chrome` one.
