### PR TITLE
Avoid missing /usr/sbin/sendmail issues during WP installation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2022-11-07
+
+* Fix - Avoid issues with missing `/usr/sbin/sendmail` during WordPress installation. [#134]
+
 ## [1.1.4] - 2022-10-27
 
 * Fix - Simplify the `restart_all_services()` code so that containers are all shut down and _then_ all started.

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.1.4';
+const CLI_VERSION = '1.1.5';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -359,6 +359,7 @@ function ensure_wordpress_installed(): bool {
 	        '$_POST["admin_password2"] = "password"; ' .
 	        '$_POST["admin_email"] = "admin@wordpress.test"; ' .
 	        '$_POST["blog_public"] = 1; ' .
+	        'function wp_mail(){ return true; } ' . // It's pluggable, this will mute it.
 	        'include "' . $install_file . '";';
 
 	$command = escapeshellarg( PHP_BINARY ) . ' -r \'' . $code . '\'';


### PR DESCRIPTION
Define the pluggable `wp_mail` function during the WordPress installation to avoid issues if the `/usr/sbin/sendmail` binary is not found.

Fixes #134 