### PR TITLE
Fix and improve XDebug toggling

### DIFF
--- a/.github/workflows/slic-wordpress-php7.3.yml
+++ b/.github/workflows/slic-wordpress-php7.3.yml
@@ -46,8 +46,8 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{raw}}
 
-      - name: Change Dockerfile to php8.0
-        run: "sed -i 's/7.4/7.3/g' containers/slic/Dockerfile"
+      - name: Change Dockerfile to php7.3
+        run: "sed -i 's/7.4/7.3/g' containers/wordpress/Dockerfile"
 
       - name: Build and push slic-wordpress Docker image
         uses: docker/build-push-action@v3.1.1

--- a/.github/workflows/slic-wordpress-php8.0.yml
+++ b/.github/workflows/slic-wordpress-php8.0.yml
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{raw}}
 
       - name: Change Dockerfile to php8.0
-        run: "sed -i 's/7.4/8.0/g' containers/slic/Dockerfile"
+        run: "sed -i 's/7.4/8.0/g' containers/wordpress/Dockerfile"
 
       - name: Build and push slic-wordpress Docker image
         uses: docker/build-push-action@v3.1.1

--- a/.github/workflows/slic-wordpress-php8.1.yml
+++ b/.github/workflows/slic-wordpress-php8.1.yml
@@ -46,8 +46,8 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{raw}}
 
-      - name: Change Dockerfile to php8.0
-        run: "sed -i 's/7.4/8.1/g' containers/slic/Dockerfile"
+      - name: Change Dockerfile to php8.1
+        run: "sed -i 's/7.4/8.1/g' containers/wordpress/Dockerfile"
 
       - name: Build and push slic-wordpress Docker image
         uses: docker/build-push-action@v3.1.1

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2022-11-14
+
+* Fix - Enable and disable XDebug correctly in WorPress and slic container removing restart requirement.
+
 ## [1.1.4] - 2022-10-27
 
 * Fix - Simplify the `restart_all_services()` code so that containers are all shut down and _then_ all started.

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -33,7 +33,8 @@ RUN chmod a+x /usr/local/bin/xdebug-on && \
 
 # Make the PHP configuration directory recursively readable and writable to allow all users to activate and deactivate XDebug.
 RUN chmod -R a+rwx /usr/local/etc/php/conf.d
-RUN echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini#A command that will keep the container running and alive.
+RUN echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN xdebug-off
 
 # Install Composer 1 and 2 from the respective images and make them world-executable.

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -3,7 +3,7 @@ FROM composer:1 AS composer1
 FROM composer:2 AS composer2
 
 # Use a fixed PHP version as base!
-FROM php:7.4.29
+FROM php:7.4.33
 
 # Install and make wp-cli binary available and executable by all users.
 ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp

--- a/containers/slic/xdebug-off.sh
+++ b/containers/slic/xdebug-off.sh
@@ -3,6 +3,3 @@
 xdebug_config_file=$(php --ini | grep xdebug | cut -d, -f1)
 sed -i '/^zend_extension/ s/zend_extension/;zend_extension/g' "$xdebug_config_file"
 php -v
-echo ""
-echo "XDebug is \033[31moff\033[0m."
-echo ""

--- a/containers/slic/xdebug-on.sh
+++ b/containers/slic/xdebug-on.sh
@@ -2,6 +2,3 @@
 xdebug_config_file=$(php --ini | grep xdebug | cut -d, -f1)
 sed -i '/^;zend_extension/ s/;zend_extension/zend_extension/g' "$xdebug_config_file"
 php -v
-echo ""
-echo "XDebug is \033[32mon\033[0m."
-echo ""

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -7,8 +7,7 @@ COPY xdebug-on.sh /usr/local/bin/xdebug-on
 COPY xdebug-off.sh /usr/local/bin/xdebug-off
 RUN chmod a+x /usr/local/bin/xdebug-on && \
     chmod a+x /usr/local/bin/xdebug-off && \
-    xdebug-off \
     echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    chmod -R a+rwx /usr/local/etc/php/conf.d
-
-#@todo restart apache on xdebug on off
+    echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    xdebug-off
+RUN chmod -R a+rwx /usr/local/etc/php/conf.d

--- a/containers/wordpress/xdebug-off.sh
+++ b/containers/wordpress/xdebug-off.sh
@@ -3,3 +3,8 @@
 xdebug_config_file=$(php --ini | grep xdebug | cut -d, -f1)
 sed -i '/^zend_extension/ s/zend_extension/;zend_extension/g' "$xdebug_config_file"
 php -v
+# Kill the oldest php-fpm process, the manager.
+pkill -o -USR2 php-fpm
+# Restart the php-fpm server and php-fpm when used as a module, ignore errors if not running.
+/etc/init.d/apache2 reload > /dev/null 2>&1
+exit 0

--- a/containers/wordpress/xdebug-on.sh
+++ b/containers/wordpress/xdebug-on.sh
@@ -2,3 +2,8 @@
 xdebug_config_file=$(php --ini | grep xdebug | cut -d, -f1)
 sed -i '/^;zend_extension/ s/;zend_extension/zend_extension/g' "$xdebug_config_file"
 php -v
+# Kill the oldest php-fpm process, the manager.
+pkill -o -USR2 php-fpm
+# Restart the php-fpm server and php-fpm when used as a module, ignore errors if not running.
+/etc/init.d/apache2 reload > /dev/null 2>&1
+exit 0

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.1.4';
+const CLI_VERSION = '1.1.5';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
This updates the XDebug configuration in the `slic` and `wordpress` images to provide, in both instances, correctly working, non-root user, `xdebug-on` and `xdebug-off` scripts.  
It removes the excess verbosity of the previous implementation and removes the requirement to restart the containers when toggling the XDebug configuration. In the context of the `wordpress` container this is achieved by restarting both the `php-fpm` service and the Apache webserver that _might_ be using `php-fpm` as a module.

The PR also contains some other smaller fixes.
