### PR TITLE
Fix init issues

### DIFF
--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -129,6 +129,8 @@ services:
       COLUMNS: "${COLUMNS:-80}"
       # Explicitly set the env var that will define the Function Mocker cache path: it will be picked up by the config file.
       FUNCTION_MOCKER_CACHE_PATH: "/cache"
+      # Share the SSH auth socket  with the container so that we can use the host machine's SSH keys.
+      SSH_AUTH_SOCK: "${DOCKER_RUN_SSH_AUTH_SOCK}"
     volumes:
       # Paths are relative to the directory that contains this file, NOT the current working directory.
       # Share the WordPress core installation files in the `_wordpress` directory.

--- a/src/commands/init.php
+++ b/src/commands/init.php
@@ -44,6 +44,11 @@ if ( empty( $plugin ) ) {
 
 clone_plugin( $plugin, $branch );
 
+if ( strpos( $plugin, '/' ) !== false ) {
+	// Normalize the plugin name to take into account the fact it might have been supplied using the `org/repo` format.
+	$plugin = explode( '/', $plugin, 2 )[1];
+}
+
 // Since the `init` command is also the one that will rebuild assets, we need to switch branch if required.
 if ( null !== $branch ) {
 	switch_plugin_branch( $branch, $plugin );
@@ -59,7 +64,7 @@ if ( getenv( 'SLIC_BUILD_PROMPT' ) ) {
 		slic_switch_target( $plugin );
 	}
 
-	$command_pool = maybe_build_install_command_pool( 'composer', $plugin, [ 'common' ] );
+	$command_pool = maybe_build_install_command_pool( composer_bin(), $plugin, [ 'common' ] );
 	$command_pool = array_merge( $command_pool, maybe_build_install_command_pool( 'npm', $plugin, [ 'common' ] ) );
 	execute_command_pool( $command_pool );
 

--- a/src/process.php
+++ b/src/process.php
@@ -236,16 +236,13 @@ function check_status_or( callable $process, callable $else = null ) {
  */
 function parallel_process( $pool ) {
 	$process_children = [];
-	// Start on the upper end of hte subnets to try and avoid overlapping pool issues.
-	$subnet_pool      = array_rand( array_flip( range( 220, 255 ) ), count( $pool ) );
-	$pool_with_subnet = array_combine( $subnet_pool, $pool );
 
 	/*
 	 * Disable parallel processing temporarily to avoid some overlapping pool issues.
 	 */
 	if ( function_exists( 'pcntl_fork' ) ) {
 		// If we're on a OS that does support process control, then fork.
-		foreach ( $pool_with_subnet as $subnet => $item ) {
+		foreach ( $pool as $item ) {
 			$pid = pcntl_fork();
 			if ( $pid === - 1 ) {
 				echo magenta( "Unable to fork processes." . PHP_EOL );
@@ -253,7 +250,7 @@ function parallel_process( $pool ) {
 			}
 
 			if ( 0 === $pid ) {
-				$item['process']( $item['target'], $subnet );
+				$item['process']( $item['target'] );
 			} else {
 				$process_children[] = $pid;
 			}

--- a/src/process.php
+++ b/src/process.php
@@ -229,12 +229,11 @@ function check_status_or( callable $process, callable $else = null ) {
  * If not the processes will be executed serially and the first failure will stop the serial execution of the
  * processes.
  *
- * @param array $items Values with which to loop over to indicate process distinction.
- * @param \Closure $command_process The closure to execute as a distinct process.
+ * @param array $pool Values with which to loop over to indicate process distinction.
  *
  * @return int The combined process status value of all child processes.
  */
-function parallel_process( $pool ) {
+function parallel_process( array $pool ): int {
 	$process_children = [];
 
 	/*
@@ -250,8 +249,10 @@ function parallel_process( $pool ) {
 			}
 
 			if ( 0 === $pid ) {
+				// Child process.
 				$item['process']( $item['target'] );
 			} else {
+				// Parent process.
 				$process_children[] = $pid;
 			}
 		}

--- a/src/slic.php
+++ b/src/slic.php
@@ -496,9 +496,8 @@ function slic_content_type_dir( $content_type = 'plugins', $path = '' ) {
  * @param string $branch The specific branch to clone. If not specified, then the default plugin repository branch
  *                       will be cloned.
  */
-function clone_plugin( $plugin, $branch = null ) {
+function clone_plugin( $plugin, $branch = null ){
 	$plugin_dir  = slic_plugins_dir();
-	$plugin_path = slic_plugins_dir( $plugin );
 
 	if ( ! file_exists( $plugin_dir ) ) {
 		echo "Creating the plugins directory..." . PHP_EOL;
@@ -508,13 +507,6 @@ function clone_plugin( $plugin, $branch = null ) {
 		}
 	}
 
-	// If the plugin path already exists, don't bother cloning.
-	if ( file_exists( $plugin_path ) ) {
-		return;
-	}
-
-	echo "Cloning {$plugin}..." . PHP_EOL;
-
 	if ( strpos( $plugin, '/' ) === false ) {
 		// The repository was specified as just a name, e.g. `the-events-calendar`.
 		$repository = git_handle() . '/' . escapeshellcmd( $plugin );
@@ -522,6 +514,17 @@ function clone_plugin( $plugin, $branch = null ) {
 		// The repository was specified to include the organization, e.g. `the-events-calendar/the-events-calendar`.
 		$repository = escapeshellcmd( $plugin );
 	}
+
+	// The plugin path should not include the org name, just the repo name.
+	$plugin_name = explode( '/', $repository, 2 )[1];
+	$plugin_path = slic_plugins_dir( $plugin_name );
+
+	// If the plugin path already exists, don't bother cloning.
+	if ( file_exists( $plugin_path ) ) {
+		return;
+	}
+
+	echo "Cloning {$plugin}..." . PHP_EOL;
 
 	$clone_command = sprintf(
 		'git clone %s --recursive git@%s:%s.git %s',
@@ -1632,4 +1635,18 @@ function cache( $path = '/', $create = true ) {
 	}
 
 	return $full_path;
+}
+
+/**
+ * Depending on the current Composer version, returns the name of the Composer binary.
+ *
+ * @since TBD
+ *
+ * @return string The name of the Composer binary.
+ */
+function composer_bin(): string {
+	$default_version = 1;
+	$current_version = getenv( 'SLIC_COMPOSER_VERSION' ) ?? $default_version;
+
+	return (int) $current_version === 1 ? 'composer1' : 'composer';
 }

--- a/src/slic.php
+++ b/src/slic.php
@@ -515,7 +515,13 @@ function clone_plugin( $plugin, $branch = null ) {
 
 	echo "Cloning {$plugin}..." . PHP_EOL;
 
-	$repository = git_handle() . '/' . escapeshellcmd( $plugin );
+	if ( strpos( $plugin, '/' ) === false ) {
+		// The repository was specified as just a name, e.g. `the-events-calendar`.
+		$repository = git_handle() . '/' . escapeshellcmd( $plugin );
+	} else {
+		// The repository was specified to include the organization, e.g. `the-events-calendar/the-events-calendar`.
+		$repository = escapeshellcmd( $plugin );
+	}
 
 	$clone_command = sprintf(
 		'git clone %s --recursive git@%s:%s.git %s',

--- a/src/slic.php
+++ b/src/slic.php
@@ -1109,7 +1109,7 @@ function build_command_pool( $base_command, array $command, array $sub_directori
 	}
 
 	// Build the command process.
-	$command_process = static function ( $target, $subnet = '' ) use ( $using, $using_alias, $base_command, $command, $sub_directories ) {
+	$command_process = static function ( $target ) use ( $using, $using_alias, $base_command, $command, $sub_directories ) {
 		$target_name = $using_alias ?: $target;
 
 		// If the command is wrapped in a bash -c "", then let's not spit out the bash -c "" part.
@@ -1134,9 +1134,6 @@ function build_command_pool( $base_command, array $command, array $sub_directori
 			$prefix          = "{$friendly_base_command}:" . yellow( $sub_target_name );
 		}
 
-		putenv( "SLIC_TEST_SUBNET={$subnet}" );
-
-		$network_name = "slic{$subnet}";
 		$status       = slic_passive()( array_merge( [
 			'exec',
 			'-T',
@@ -1144,22 +1141,9 @@ function build_command_pool( $base_command, array $command, array $sub_directori
 			sprintf( '"%s:%s"', getenv( 'SLIC_UID' ), getenv( 'SLIC_GID' ) ),
 			'--workdir',
 			escapeshellarg( get_project_container_path() ),
-			$network_name,
+			'slic',
 			$base_command
 		], $command ), $prefix );
-
-		if ( ! empty( $subnet ) ) {
-			do {
-				/*
-				 * Some containers might take time to terminate after yielding control back to the Docker daemon (zombies).
-				 * If we try to remote the network when zombie containers are attached to it, we'll get the following error:
-				 * "error while removing network: network <network_name> id <id> has active endpoints".
-				 * When this happens, the return status of the command will be a `1`.
-				 * We iterate until the status is a `0`.
-				 */
-				$network_rm_status = (int) process( "docker network rm {$network_name}_slic {$network_name}_default" )( 'status' );
-			} while ( $network_rm_status !== 0 );
-		}
 
 		if ( 'target' !== $target ) {
 			slic_switch_target( $using );


### PR DESCRIPTION
This updates the `init` command, and related code, to remove the concept of subnet-based parallel execution and to make sure plugins can be initialized using the `org/repository` format.  
The change of the default handle to `stellarwp` made it impossible to run a command like `slic init the-events-calendar` correctly, since it will be pointed to `stellarwp/the-events-calendar`, a not existing repository. The update changes the logic to support commands like this:

```
slic init the-events-calendar/the-events-calendar
```

to clone and init plugins independently of the current `SLIC_GIT_HANDLE` value.
