### PR TITLE
Fix PHP 8.2 deprecation notices for old variable syntax.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2023-01-03
+
+* Fix - Modernize variable syntax to avoid PHP 8.2 deprecation notices.
+
 ## [1.1.5] - 2022-11-29
 
 * Fix - Enable and disable XDebug correctly in WorPress and slic container removing restart requirement.

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.1.5';
+const CLI_VERSION = '1.1.6';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/src/slic.php
+++ b/src/slic.php
@@ -178,7 +178,7 @@ function ensure_valid_target( $target, $exit = true ) {
 		$target = get_cwd_dir_name();
 
 		if ( ! in_array( $target, $targets, true ) ) {
-			echo magenta( "Detecting the current directory of '{$target}' as the target was not valid." . PHP_EOL . "Available targets are: " . PHP_EOL . "${targets_str}" . PHP_EOL );
+			echo magenta( "Detecting the current directory of '{$target}' as the target was not valid." . PHP_EOL . "Available targets are: " . PHP_EOL . "{$targets_str}" . PHP_EOL );
 			if ( $exit ) {
 				exit( 1 );
 			}
@@ -188,7 +188,7 @@ function ensure_valid_target( $target, $exit = true ) {
 	}
 
 	if ( ! in_array( $target, $targets, true ) ) {
-		echo magenta( "'{$target}' is not a valid target; available targets are:" . PHP_EOL . "${targets_str}" . PHP_EOL );
+		echo magenta( "'{$target}' is not a valid target; available targets are:" . PHP_EOL . "{$targets_str}" . PHP_EOL );
 		if ( $exit ) {
 			exit( 1 );
 		}

--- a/src/utils.php
+++ b/src/utils.php
@@ -70,7 +70,7 @@ function load_env_file( $env_file ) {
 	$env_lines = read_env_file( $env_file );
 
 	foreach ( $env_lines as $key => $value ) {
-		putenv( "${key}={$value}" );
+		putenv( "{$key}={$value}" );
 	}
 }
 
@@ -83,7 +83,7 @@ function load_env_file( $env_file ) {
  */
 function read_env_file( $env_file ) {
 	if ( ! file_exists( $env_file ) ) {
-		echo PHP_EOL . "env file ${env_file} does not exist.";
+		echo PHP_EOL . "env file {$env_file} does not exist.";
 		exit( 1 );
 	}
 


### PR DESCRIPTION
https://d.pr/i/NUbtdI

https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated#:~:text=Deprecated%3A%20Using%20%24%7Bvar%7D%20in,not%20cause%20the%20deprecation%20notice.