### PR TITLE
Added the `--skip-rebuild` option to the `slic php-version set` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2023-02-22
+
+* Added - The `--skip-rebuild` option to the `slic php-version set` command to allow setting the PHP version without rebuilding the stack in order to speed up CI runs. Example: `slic php-version set 8.1 --skip-rebuild`
+* Fix - `slic php-version help` will now properly show command help text.
+* Fix - `slic php-version` will now properly use the default PHP version if the `SLIC_PHP_VERSION` env var is not set.
+
 ## [1.1.7] - 2023-02-21
 
 * Change - The WordPress PHP7.3 image is only available in for WordPress 5.9.x.

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.1.7';
+const CLI_VERSION = '1.2.0';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
With `slic interactive off` and using `slic php-version set 8.1` in GitHub workflows, this forces an unneeded pull of the 7.4 docker container, slowing down the workflow (saves me about 1.25 minutes per run).

* Added - The `--skip-rebuild` option to the `slic php-version set` command to allow setting the PHP version without rebuilding the stack in order to speed up CI runs. Example: `slic php-version set 8.1 --skip-rebuild`
* Fix - `slic php-version help` will now properly show command help text.
* Fix - `slic php-version` will now properly use the default PHP version if the `SLIC_PHP_VERSION` env var is not set.