### PR TITLE
Cache docker images via the GitHub cache API

### DIFF
--- a/.github/workflows/publish-slic-docker-image.yml
+++ b/.github/workflows/publish-slic-docker-image.yml
@@ -66,6 +66,8 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             NODE_VERSION=16.6.1

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -65,6 +65,8 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             WP_VERSION=${{ matrix.wp_version }}

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2023-02-22
+
+* Changed - Add docker build caching using the [GitHub Cache Backend](https://docs.docker.com/build/ci/github-actions/examples/#github-cache) when publishing docker images via GitHub actions.
+
 ## [1.2.0] - 2023-02-21
 
 * Change - Display composer version in `slic info`.


### PR DESCRIPTION
This should hopefully speed up the slic image publishing significantly. 

* Changed - Add docker build caching using the [GitHub Cache Backend](https://docs.docker.com/build/ci/github-actions/examples/#github-cache) when publishing docker images via GitHub actions.