### PR TITLE
Add COMPOSER_AUTH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,33 @@ If you want to know which version `slic` is pointed at, you can always call:
 
 `slic composer get-version`
 
+### Installing private packages with composer
+
+If you need to install a private composer package, configure the [COMPOSER_AUTH](https://getcomposer.org/doc/03-cli.md#composer-auth) environment variable. For example, to install a package from a private GitHub repository:
+
+> Note: You may need to create a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
+```shell
+export COMPOSER_AUTH='{"github-oauth": {"github.com": "YOUR_TOKEN_HERE"}}'
+```
+
+Then, restart slic and try again:
+
+```shell
+slic restart; slic composer update
+```
+
+Or, in a GitHub Action, for example:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GH_BOT_TOKEN }}"}}'
+```
+
 ### Customizing `slic`'s `.env` file
 
 The `slic` CLI command leverages `.env.*` files to dictate its inner workings. It loads `.env.*` files in the following order, the later files overriding the earlier ones:

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2023-03-20
+
+* Added - Pass through the [COMPOSER_AUTH](https://getcomposer.org/doc/03-cli.md#composer-auth) environment variable to the slic docker container to allow composer installs for private or otherwise protected dependencies. Especially useful when running in GitHub Actions.
+
 ## [1.2.2] - 2023-02-24
 
 * Change - No longer build gd in the slick docker container with AVIF, fixing external dependency on the currently down code.videolan.org, and speeding up builds - [more info](https://github.com/mlocati/docker-php-extension-installer#configuration).

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -100,6 +100,7 @@ services:
       - slic
     user: "${SLIC_UID:-}:${SLIC_GID:-}"
     environment:
+      COMPOSER_AUTH: "${COMPOSER_AUTH:-}"
       COMPOSER_CACHE_DIR: "/composer-cache"
       # Set these values to allow the container to look wordpress up.
       WORDPRESS_DB_USER: root


### PR DESCRIPTION
* Added - Pass through the [COMPOSER_AUTH](https://getcomposer.org/doc/03-cli.md#composer-auth) environment variable to the slic docker container to allow composer installs for private or otherwise protected dependencies. Especially useful when running in GitHub Actions.