### PR TITLE
Bugfix: Allow site target with WP root directory tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2023-03-31
+
+* Updates slic-stack.site.yml for full site testing.
+* Adds check for `site` target to refrence `slic_wp_dir()` when running commands.
+
 ## [1.3.1] - 2023-03-31
 
 * Change - Default to Composer version 2.

--- a/slic-stack.site.yml
+++ b/slic-stack.site.yml
@@ -10,30 +10,7 @@ services:
       # Share the WordPress core installation files in the `_wordpress` directory.
       - ${SLIC_WP_DIR}:/var/www/html
 
-  cli:
-    volumes:
-      # Paths are relative to the directory that contains this file, NOT the current working directory.
-      # Share the WordPress core installation files in the `_wordpress` directory.
-      - ${SLIC_WP_DIR}:/var/www/html
-
-  codeception:
+  slic:
     environment:
       # Move to the target directory before running the command from the plugins directory.
-      CODECEPTION_PROJECT_DIR: /var/www/html/${SLIC_CURRENT_PROJECT_RELATIVE_PATH}
-    volumes:
-      # Set the current site as project.
-      - ${SLIC_HERE_DIR}/${SLIC_CURRENT_PROJECT_RELATIVE_PATH}:/project
-      # Paths are relative to the directory that contains this file, NOT the current working directory.
-      # Share the WordPress core installation files in the `_wordpress` directory.
-      - ${SLIC_WP_DIR}:/var/www/html
-
-  composer:
-    volumes:
-      # Set the current target as project.
-      - ${SLIC_HERE_DIR}/${SLIC_CURRENT_PROJECT_RELATIVE_PATH}:/project
-      - ${COMPOSER_CACHE_DIR}:${COMPOSER_CACHE_DIR}
-
-  npm:
-    volumes:
-      # Set the current plugin as project.
-      - ${SLIC_HERE_DIR}/${SLIC_CURRENT_PROJECT_RELATIVE_PATH}:/project
+      CODECEPTION_PROJECT_DIR: /var/www/html

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -56,6 +56,11 @@ maybe_generate_htaccess();
 // Run the command in the Codeception container.
 $root = slic_plugins_dir( slic_target( true ) );
 
+// If target is site, set the root to the wp dir.
+if ( 'site' === slic_target() ) {
+	$root = slic_wp_dir();
+}
+
 // Object-cache is disruptive in the context of tests; remove the object cache drop-in before running the tests.
 $object_cache_dropin = slic_wp_dir( 'wp-content/object-cache.php' );
 if ( file_exists( $object_cache_dropin ) ) {

--- a/src/slic.php
+++ b/src/slic.php
@@ -1079,7 +1079,8 @@ function build_command_pool( $base_command, array $command, array $sub_directori
 	$targets     = [];
 
 	// If applicable, include target plugin before subdirectory plugins.
-	if ( dir_has_req_build_file( $base_command, slic_plugins_dir( slic_target() ) ) ) {
+	$path = $using === 'site' ? slic_wp_dir() : slic_plugins_dir( slic_target() );
+	if ( dir_has_req_build_file( $base_command, $path ) ) {
 		$targets[] = 'target';
 	}
 


### PR DESCRIPTION
I was testing out `slic` to use at the agency level for full-site builds. 

When running using the `site` target I was [getting an error and the docker composer](http://p.tri.be/i/dWNeBP) wouldn't run and it would throw an error for each service that wasn't referenced in the `slic-stack.yml` but was referenced in `slic-stack.site.yml`. 

This should take care of the issue and allow you to run tests from the WP root directory if you are using the `site` target again. 