### PR TITLE
Fix broken line break output when running via docker compose v2.2.x

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2023-04-03
+
+* Fix - broken CRLF line breaks via slic real-time commands due to docker compose v2.2.x being used [Docker compose issue](https://github.com/docker/compose/issues/8833#issuecomment-953023240).
+
 ## [1.3.2] - 2023-04-03
 
 * Updates slic-stack.site.yml for full site testing.

--- a/src/process.php
+++ b/src/process.php
@@ -45,8 +45,12 @@ function process_realtime( $command ) {
 
 	setup_terminal();
 
+	$is_windows                = DIRECTORY_SEPARATOR === '\\';
+	$is_docker_compose_cmd = strpos( $command, docker_compose_bin() ) === 0;
+
 	// Fix broken line break output for docker compose v2.2.x: https://github.com/docker/compose/issues/8833#issuecomment-953023240
-	$clean_command = escapeshellcmd( $command ) . ' </dev/null';
+	$dc_issue_8833_fix_postfix = $is_windows || ! $is_docker_compose_cmd ? '' : ' </dev/null';
+	$clean_command             = escapeshellcmd( $command ) . $dc_issue_8833_fix_postfix;
 
 	debug( "Executing command: $clean_command" );
 

--- a/src/process.php
+++ b/src/process.php
@@ -49,7 +49,7 @@ function is_tty_supported(): bool {
  * @return bool
  */
 function is_dc_exec_command( string $command ): bool {
-	return strpos( $command, docker_compose_bin() ) !== false && strpos( $command, ' exec ' );
+	return strpos( $command, docker_compose_bin() ) !== false && strpos( $command, ' exec ' ) !== false;
 }
 
 /**

--- a/src/process.php
+++ b/src/process.php
@@ -31,10 +31,23 @@ function process( $command ) {
 	};
 }
 
+/**
+ * Returns whether TTY is supported on the current operating system.
+ *
+ * @return bool
+ */
 function is_tty_supported(): bool {
 	return ( '/' === \DIRECTORY_SEPARATOR && stream_isatty( \STDOUT ) );
 }
 
+/**
+ * Returns whether we're attempting to run a "docker compose" or "docker-compose"
+ * command.
+ *
+ * @param string $command The command to run.
+ *
+ * @return bool
+ */
 function is_docker_compose_command( string $command ): bool {
 	return strpos( $command, docker_compose_bin() ) !== false;
 }

--- a/src/process.php
+++ b/src/process.php
@@ -48,8 +48,8 @@ function is_tty_supported(): bool {
  *
  * @return bool
  */
-function is_docker_compose_command( string $command ): bool {
-	return strpos( $command, docker_compose_bin() ) !== false;
+function is_dc_exec_command( string $command ): bool {
+	return strpos( $command, docker_compose_bin() ) !== false && strpos( $command, ' exec ' );
 }
 
 /**
@@ -62,16 +62,16 @@ function is_docker_compose_command( string $command ): bool {
  * @return int The process exit status, `0` means ok.
  */
 function process_realtime( $command ) {
-	echo PHP_EOL;
-
 	setup_terminal();
 
 	// Fix broken line break output for docker compose v2.2.x: https://github.com/docker/compose/issues/8833#issuecomment-953023240
-	$dc_issue_8833_fix_postfix = ( is_docker_compose_command( $command ) && is_tty_supported() ) ? ' </dev/null' : '';
+	$dc_issue_8833_fix_postfix = ( is_dc_exec_command( $command ) && is_tty_supported() ) ? ' </dev/null' : '';
 
 	$clean_command = escapeshellcmd( $command ) . $dc_issue_8833_fix_postfix;
 
 	debug( "Executing command: $clean_command" );
+
+	echo PHP_EOL;
 
 	passthru( $clean_command, $status );
 

--- a/src/process.php
+++ b/src/process.php
@@ -35,7 +35,7 @@ function is_tty_supported(): bool {
 	return ( '/' === \DIRECTORY_SEPARATOR && stream_isatty( \STDOUT ) );
 }
 
-function is_docker_composer_command( string $command ): bool {
+function is_docker_compose_command( string $command ): bool {
 	return strpos( $command, docker_compose_bin() ) !== false;
 }
 
@@ -54,7 +54,7 @@ function process_realtime( $command ) {
 	setup_terminal();
 
 	// Fix broken line break output for docker compose v2.2.x: https://github.com/docker/compose/issues/8833#issuecomment-953023240
-	$dc_issue_8833_fix_postfix = ( is_docker_composer_command( $command ) && is_tty_supported() ) ? ' </dev/null' : '';
+	$dc_issue_8833_fix_postfix = ( is_docker_compose_command( $command ) && is_tty_supported() ) ? ' </dev/null' : '';
 
 	$clean_command = escapeshellcmd( $command ) . $dc_issue_8833_fix_postfix;
 

--- a/src/process.php
+++ b/src/process.php
@@ -37,18 +37,18 @@ function process( $command ) {
  * Realtime processes are done without forking, have no need of prefixes, and support interactivity.
  *
  * @param string $command The command to run.
- * @param string|null $prefix The prefix to place before all output.
  *
  * @return int The process exit status, `0` means ok.
  */
 function process_realtime( $command ) {
-	debug( "Executing command: {$command}" );
-
 	echo PHP_EOL;
 
 	setup_terminal();
 
-	$clean_command = escapeshellcmd( $command );
+	// Fix broken line break output for docker compose v2.2.x: https://github.com/docker/compose/issues/8833#issuecomment-953023240
+	$clean_command = escapeshellcmd( $command ) . ' </dev/null';
+
+	debug( "Executing command: $clean_command" );
 
 	passthru( $clean_command, $status );
 


### PR DESCRIPTION
Since upgrading to the new `docker compose` binary (running v2.2.2 on my system), line break outputs have been broken when `docker compose exec` is run. [GitHub Issue](https://github.com/docker/compose/issues/8833), [work around](https://github.com/docker/compose/issues/8833#issuecomment-953023240)

Before this bugfix:
![image](https://user-images.githubusercontent.com/1066195/229587310-15a6def3-daf6-4f09-834f-531d2879c16e.png)

After this bugfix: 
![image](https://user-images.githubusercontent.com/1066195/229587427-398300d0-11d6-44d3-86d1-7eac7c32ce74.png)

I tested it as well with `docker-compose`, which is running v2.17.2 on my system and this didn't change the output either way, so it seems backwards compatible.

I also tested running with `docker compose exec -T` but that didn't make a difference either way, with or without the trailing `' </dev/null'`.
