### PR TITLE
Update WordPress to 6.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2023-06-21
+
+* Change - Update WordPress version to 6.2.2.
+
 ## [1.3.3] - 2023-04-04
 
 * Fix - broken CRLF line breaks via slic real-time commands due to docker compose v2.2.x being used [Docker compose issue](https://github.com/docker/compose/issues/8833#issuecomment-953023240).

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0] - 2023-06-21
 
-* Change - Update WordPress version to 6.2.2.
+* Change - Update WordPress version to 6.1 (the last WP version with a PHP 7.4 image).
 
 ## [1.3.3] - 2023-04-04
 

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -1,6 +1,6 @@
 ARG WORDPRESS_IMAGE_VERSION=wordpress/apache
 ARG PHP_VERSION=7.4
-ARG WP_VERSION=6.0.2
+ARG WP_VERSION=6.2.2
 
 FROM wordpress:${WP_VERSION}-php${PHP_VERSION}-apache
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -1,6 +1,6 @@
 ARG WORDPRESS_IMAGE_VERSION=wordpress/apache
 ARG PHP_VERSION=7.4
-ARG WP_VERSION=6.2.2
+ARG WP_VERSION=6.1
 
 FROM wordpress:${WP_VERSION}-php${PHP_VERSION}-apache
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/


### PR DESCRIPTION
This is a simple change to up the included WP version. WooCommerce no longer supports WP < 6.1.

## Why not WordPress 6.2.2?

It looks like there isn't an [official WordPress image](https://hub.docker.com/_/wordpress/) with PHP 7.4 on any version of WP > 6.1. We'll have to figure that out. Until then, let's bump up to 6.1.