### PR TITLE
Allows for the generation of code coverage reports

### DIFF
--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -47,7 +47,7 @@ RUN chmod a+x /usr/local/bin/xdebug-on && \
 
 # Make the PHP configuration directory recursively readable and writable to allow all users to activate and deactivate XDebug.
 RUN chmod -R a+rwx /usr/local/etc/php/conf.d
-RUN echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+RUN echo "xdebug.mode=develop,debug,coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN xdebug-off
 

--- a/containers/slic/php.ini
+++ b/containers/slic/php.ini
@@ -17,5 +17,5 @@ max_execution_time=300
 
 ;If XDebug is active, it should always start.
 xdebug.start_with_request=yes
-xdebug.mode=develop,debug
+xdebug.mode=develop,debug,coverage
 xdebug.discover_client_host=1

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -9,7 +9,7 @@ COPY xdebug-on.sh /usr/local/bin/xdebug-on
 COPY xdebug-off.sh /usr/local/bin/xdebug-off
 RUN chmod a+x /usr/local/bin/xdebug-on && \
     chmod a+x /usr/local/bin/xdebug-off && \
-    echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    echo "xdebug.mode=develop,debug,coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     xdebug-off
 RUN chmod -R a+rwx /usr/local/etc/php/conf.d


### PR DESCRIPTION
The docker containers are missing the `coverage` option for  `xdebug.mode`. With this added we should be able to properly generate code coverage reports.

### Steps

Add to your project's `codeception.dist.yml`:

```yml
coverage:
  enabled: true
  include:
    - src/* # or wherever your code lives
```    

Then execute:

```shell
slic xdebug on
```

```shell
slic run --coverage --coverage-html
```

Then the project will have an HTML code coverage report in: `tests/_output/coverage`.