### PR TITLE
Version 1.4.4

### DIFF
--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         wp_version: [ '6.2' ]
-        php_version: [ '7.4', '8.0', '8.1' ]
+        php_version: [ '7.4', '8.0', '8.1', '8.2' ]
         include:
           # WordPress did not publish any 6.x images for PHP 7.3, use the latest 5.9 patch.
           - wp_version: '5.9'

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -17,11 +17,16 @@ jobs:
     strategy:
       matrix:
         wp_version: [ '6.2' ]
-        php_version: [ '7.4', '8.0', '8.1', '8.2' ]
+        php_version: [ '8.0', '8.1', '8.2' ]
         include:
-          # WordPress did not publish any 6.x images for PHP 7.3, use the latest 5.9 patch.
+          # No WordPress image for version 6.2+ and PHP 7.3: use the latest 5.9 version.
+          # This version is NOT udpated in the containers/wordpress/Dockerfile for back-compatibility.
           - wp_version: '5.9'
             php_version: '7.3'
+          # No WordPress image for version 6.2+ and PHP 7.4: use the latest 6.1.1 version.
+          # See containers/wordpress/Dockerfile for the wp-cli update to version 6.2.
+          - wp_version: '6.1.1'
+            php_version: '7.4'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -16,15 +16,12 @@ jobs:
       packages: write
     strategy:
       matrix:
-        wp_version: [ '6.1' ]
+        wp_version: [ '6.2' ]
         php_version: [ '7.4', '8.0', '8.1' ]
         include:
           # WordPress did not publish any 6.x images for PHP 7.3, use the latest 5.9 patch.
           - wp_version: '5.9'
             php_version: '7.3'
-          # WordPress did not publish earlier versions of WP for PHP8.2.
-          - wp_version: '6.1.1'
-            php_version: '8.2'
 
     steps:
       - name: Checkout repository

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.4.4] - 2023-08-15
+* Change - Update base WordPress container from 6.1 to 6.2.
+
 # [1.4.3] - 2023-08-03
 
 * Change - Configure `slic` and `wordpress` containers consistently with `php.ini` configuration file.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [1.4.4] - 2023-08-15
 * Change - Update base WordPress container from 6.1 to 6.2.
+* Change - Add WP CLI to the `wordpress` container as `wp`.
 
 # [1.4.3] - 2023-08-03
 

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -13,3 +13,13 @@ RUN chmod a+x /usr/local/bin/xdebug-on && \
 RUN chmod -R a+rwx /usr/local/etc/php/conf.d
 # Use our own ini configuration file to set up some PHP default.
 COPY ./php.ini /usr/local/etc/php/conf.d/999-slic.ini
+
+# Install and make wp-cli binary available and executable by all users.
+ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp
+RUN chmod a+rx /usr/local/bin/wp
+
+# If PHP_VERSION is 7.4, the use wp-cli to update wordpress to version 6.2.
+# No image is available for wordpress 6.2 with PHP 7.4: this works around the issue.
+RUN if [ "${PHP_VERSION}" = "7.4" ]; then \
+    wp core update --version=6.2 --force; \
+    fi

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -22,5 +22,5 @@ RUN chmod a+rx /usr/local/bin/wp
 # If PHP_VERSION is 7.4, update WordPress to 6.2 using wp-cli.
 # Weird syntax? POSIX compliant sh.
 RUN if echo "${PHP_VERSION}" | grep -q '^7.4'; then \
-    wp --allow-root --path=/var/www/html core download --version=6.2 --force; \
+    wp --allow-root --path=/usr/src/wordpress core download --version=6.2 --force; \
     fi

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -18,8 +18,9 @@ COPY ./php.ini /usr/local/etc/php/conf.d/999-slic.ini
 ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp
 RUN chmod a+rx /usr/local/bin/wp
 
-# If PHP_VERSION is 7.4, the use wp-cli to update wordpress to version 6.2.
-# No image is available for wordpress 6.2 with PHP 7.4: this works around the issue.
-RUN if [ "${PHP_VERSION}" = "7.4" ]; then \
-    wp core update --version=6.2 --force; \
+# No image for WordPress 6.2+ is available for PHP 7.4.
+# If PHP_VERSION is 7.4, update WordPress to 6.2 using wp-cli.
+# Weird syntax? POSIX compliant sh.
+RUN if echo "${PHP_VERSION}" | grep -q '^7.4'; then \
+    wp --allow-root --path=/var/www/html core download --version=6.2 --force; \
     fi

--- a/slic.php
+++ b/slic.php
@@ -33,7 +33,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.4.3';
+const CLI_VERSION = '1.4.4';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -145,60 +145,6 @@ function ensure_wordpress_installed(): bool {
 }
 
 /**
- * Fetch and return WordPress current latest version string.
- *
- * The result is cached in file for a day.
- *
- * @return string The current latest version, or `1.0.0` if the information
- *                could not be retrieved.
- */
-function get_wordpress_latest_version(): string {
-	static $current_latest_version;
-
-	if ( $current_latest_version !== null ) {
-		return $current_latest_version;
-	}
-
-	$cache_file = cache( 'wp_latest_version.txt' );
-
-	// Invalidate after a day.
-	if ( is_readable( $cache_file ) && ( time() - (int) filectime( $cache_file ) ) < 86400 ) {
-		debug( "Reading latest version string from cache file $cache_file." . PHP_EOL );
-
-		$current_latest_version = file_get_contents( $cache_file );
-
-		return $current_latest_version;
-	}
-
-	debug( "Fetching latest WordPress version string ..." . PHP_EOL );
-	$json = file_get_contents( 'https://api.wordpress.org/core/version-check/1.7/' );
-
-	if ( $json === false ) {
-		debug( 'Fetching of WordPress latest version string failed, falling back to 1.0.0.' );
-
-		// We could not tell, return something that will trigger a refresh.
-		return '1.0.0';
-	}
-
-	$decoded = json_decode( $json, true );
-
-	if ( $decoded !== false && isset( $decoded['offers'][0]['current'] ) ) {
-		$current_latest_version = $decoded['offers'][0]['current'];
-
-		debug( "Fetched WordPress latest version: $current_latest_version" . PHP_EOL );
-
-		file_put_contents( $cache_file, $current_latest_version );
-
-		return $current_latest_version;
-	}
-
-	debug( "Fetched latest version response malformed, falling back to 1.0.0" . PHP_EOL );
-
-	// We could not tell, return something that will trigger a refresh.
-	return '1.0.0';
-}
-
-/**
  * Ensure, failing if not possible, that WordPress is correctly set up, configured and installed.
  *
  * @param string|null $version The WordPress version to ensure the readiness of, `latest` if null.


### PR DESCRIPTION
This PR is born to mitigate the issue where some plugins, like ET+, would require version `6.2+` of WordPress.
The version, fixed in the Dockerfile, cannot be updated in CI and must be shipped with the image.

This PR updates the code to build the `wordpress` image to:
* build based on `6.2` for PHP `8.0+`
* build based on `6.1.1` for PHP `7.4` as there is no official WordPress image for PHP 7.4 and WordPress 6.2+; the `containers/wordpress/Dockerfile` will detect PHP version 7.4 and will update WordPress, [in the source directory it's pulled from](https://github.com/docker-library/wordpress/blob/master/docker-entrypoint.sh#L38-L42), to version 6.2.

This system can be used to handle other future incompatibilities.