### PR TITLE
Automate xdebug support on Linux

### DIFF
--- a/.env.slic
+++ b/.env.slic
@@ -56,8 +56,9 @@ XDK=slic
 # Whether to enable XDebug in the containers or not.
 XDE=0
 # The remote host XDebug should connect to.
-# This default value should work out of the box on Docker for Mac and Windows, but it will not on Linux.
-# Override this value in the .env.slic.local file if required.
+# This default value should work out of the box on Docker for Mac and Windows.
+# On Linux, this is automatically set in src/slic.php to make the Docker gateway IP map to this host.
+# Override this value in the .env.slic.local file, if required.
 # E.g. to get the current host IP on Debian derivatives: ip route | grep docker0 | awk '{print $9}'
 XDH=host.docker.internal
 # The remote host port XDebug will connect to. Avoids the default 9000 as your host machine might have php-fpm already

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.4.5] - 2023-09-06
+* Fix - Added `extra_hosts:"${host:-host}:host-gateway"` to slick-stack.yml for Linux compatibility, enabling Xdebug without modifying the XDH environment variable. [Ref](https://github.com/docker/for-linux/issues/264#issuecomment-785247571).
+
 # [1.4.4] - 2023-08-15
 * Change - Update base WordPress container from 6.1 to 6.2.
 * Change - Add WP CLI to the `wordpress` container as `wp`.

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -114,6 +114,9 @@ services:
       interval: 1s
       timeout: 3s
       retries: 30
+    extra_hosts:
+      # set as host=host.docker.internal in src/slic.php on Linux for xdebug
+      - "${host:-host}:host-gateway"
 
   chrome:
     image: ${SLIC_CHROME_CONTAINER:-selenium/standalone-chrome:3.141.59}
@@ -191,3 +194,6 @@ services:
       - ${COMPOSER_CACHE_DIR:-./.cache}:/composer-cache
       # Scripts volume
       - ${SLIC_SCRIPTS}:/slic-scripts
+    extra_hosts:
+      # set as host=host.docker.internal in src/slic.php on Linux for xdebug
+      - "${host:-host}:host-gateway"

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -115,7 +115,7 @@ services:
       timeout: 3s
       retries: 30
     extra_hosts:
-      # set as host=host.docker.internal in src/slic.php on Linux for xdebug
+      # Set as host=host.docker.internal in src/slic.php on Linux for XDebug.
       - "${host:-host}:host-gateway"
 
   chrome:
@@ -195,5 +195,5 @@ services:
       # Scripts volume
       - ${SLIC_SCRIPTS}:/slic-scripts
     extra_hosts:
-      # set as host=host.docker.internal in src/slic.php on Linux for xdebug
+      # Set as host=host.docker.internal in src/slic.php on Linux for XDebug.
       - "${host:-host}:host-gateway"

--- a/src/slic.php
+++ b/src/slic.php
@@ -267,6 +267,13 @@ function setup_slic_env( $root_dir, $reset = false ) {
 		load_env_file( $root_dir . '/.env.slic.run' );
 	}
 
+	// Set the host env var to make xdebug work on Linux with host.docker.internal.
+	// This will already be set on Mac/Windows, and overriding it would break things.
+	// See extra_hosts: in slick-stack.yml.
+	if ( PHP_OS === 'Linux' ) {
+		putenv( sprintf( 'host=%s', getenv( 'XDH' ) ?: 'host.docker.internal' ) );
+	}
+
 	$default_wp_dir = root( '/_wordpress' );
 	$wp_dir         = getenv( 'SLIC_WP_DIR' );
 

--- a/src/slic.php
+++ b/src/slic.php
@@ -267,9 +267,11 @@ function setup_slic_env( $root_dir, $reset = false ) {
 		load_env_file( $root_dir . '/.env.slic.run' );
 	}
 
-	// Set the host env var to make xdebug work on Linux with host.docker.internal.
-	// This will already be set on Mac/Windows, and overriding it would break things.
-	// See extra_hosts: in slick-stack.yml.
+	/*
+	 * Set the host env var to make xdebug work on Linux with host.docker.internal.
+	 * This will already be set on Mac/Windows, and overriding it would break things.
+	 * See extra_hosts: in slick-stack.yml.
+	 */
 	if ( PHP_OS === 'Linux' ) {
 		putenv( sprintf( 'host=%s', getenv( 'XDH' ) ?: 'host.docker.internal' ) );
 	}


### PR DESCRIPTION
> ⚠️ **Please test this on a Mac!** - This shouldn't break anything, but make sure you can use xdebug properly as before after restarting slic as I don't have a Mac to test with.

This automates xdebug support on Linux, putting the correct IP in the container's hosts file with the `host.docker.internal` name just like on a Mac/Windows.

Confirm my Docker gateway IP:
```shell
$ ip route | grep docker0 | awk '{print $9}'
172.17.0.1
```

```shell
slic shell
```

`172.17.0.1	host.docker.internal` is now added to /etc/hosts:
```shell
[slic@slic] /var/www/html/wp-content/plugins/whatever
 > cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.17.0.1	host.docker.internal
172.28.0.6	970efb9ed2ce
```


Ref: https://github.com/docker/for-linux/issues/264#issuecomment-785247571