### PR TITLE
Added check for Docker bug for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ _plugins
 
 # slic own cache directory
 .cache
+
+# slic lastruntime
+.lastruntime

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [TBD] - TBD
+* Change - Added check on Linux for User ID 100999 and Group 100999 issue that occurs with [Docker](https://github.com/docker/desktop-linux/issues/31).
+
 # [1.5.0] - 2023-09-06
 * Fix - Added `extra_hosts:"${host:-host}:host-gateway"` to slick-stack.yml for Linux compatibility, enabling Xdebug without modifying the XDH environment variable. [Ref](https://github.com/docker/for-linux/issues/264#issuecomment-785247571).
 

--- a/src/commands/here.php
+++ b/src/commands/here.php
@@ -49,6 +49,13 @@ if ( empty( $reset ) ) {
 	$here_dir = $plugins_dir;
 }
 
+// Due to a Docker bug, confirm Linux has proper permissions, otherwise output an error.
+$check_permissions = confirm_linux_has_file_permissions( [ $here_dir, $wp_dir, $themes_dir ] );
+
+if ( $check_permissions !== true ) {
+	echo red( $check_permissions );
+}
+
 $has_wp_config = dir_has_wp_config( $here_dir );
 $env_values    = [];
 

--- a/src/commands/here.php
+++ b/src/commands/here.php
@@ -50,11 +50,7 @@ if ( empty( $reset ) ) {
 }
 
 // Due to a Docker bug, confirm Linux has proper permissions, otherwise output an error.
-$check_permissions = confirm_linux_has_file_permissions( [ $here_dir, $wp_dir, $themes_dir ] );
-
-if ( $check_permissions !== true ) {
-	echo red( $check_permissions );
-}
+ confirm_linux_has_file_permissions( [ $here_dir, $wp_dir, $themes_dir ] );
 
 $has_wp_config = dir_has_wp_config( $here_dir );
 $env_values    = [];

--- a/src/commands/reset.php
+++ b/src/commands/reset.php
@@ -38,6 +38,13 @@ $targets = $args( '...' );
 
 quietly_tear_down_stack();
 
+$lastruntime = root( '/.lastruntime' );
+echo "Removing {$lastruntime} ... ";
+echo ( ! file_exists( $lastruntime ) || unlink( $lastruntime ) ) ?
+	light_cyan( 'done' )
+	: magenta( 'fail, remove it manually' );
+echo PHP_EOL;
+
 $run_settings_file = root( '/.env.slic.run' );
 echo "Removing {$run_settings_file} ... ";
 echo ( ! file_exists( $run_settings_file ) || unlink( $run_settings_file ) ) ?

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -50,11 +50,7 @@ $codeception_args = array_merge( [ 'run' ], $args( '...' ) );
 ensure_service_running( 'slic' );
 
 // Due to a Docker bug, confirm Linux has proper permissions, otherwise output an error.
-$check_permissions = confirm_linux_has_file_permissions( [ slic_wp_dir(), slic_plugins_dir( slic_target( true ) ) ] );
-
-if ( $check_permissions !== true ) {
-	echo red( $check_permissions );
-}
+confirm_linux_has_file_permissions( [ slic_wp_dir(), slic_plugins_dir( slic_target( true ) ) ] );
 
 setup_id();
 

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -49,6 +49,13 @@ echo light_cyan( "Using {$using}" . PHP_EOL );
 $codeception_args = array_merge( [ 'run' ], $args( '...' ) );
 ensure_service_running( 'slic' );
 
+// Due to a Docker bug, confirm Linux has proper permissions, otherwise output an error.
+$check_permissions = confirm_linux_has_file_permissions( [ slic_wp_dir(), slic_plugins_dir( slic_target( true ) ) ] );
+
+if ( $check_permissions !== true ) {
+	echo red( $check_permissions );
+}
+
 setup_id();
 
 maybe_generate_htaccess();


### PR DESCRIPTION
This PR adds some additional messaging when a user on Linux runs Slic with their files set to ID 100999 or group 100999. I spoke with Luca on the best route and we decided outputting messaging would be the best direction. 

I added the check when `slic here` and `slic run` is ran.

Artifact - 
Updated Artifacts after changes -

![image](https://github.com/stellarwp/slic/assets/12241059/2e2c80f0-03f0-498f-97be-d0633d8edd92)

---
`slic here` -
![image](https://github.com/stellarwp/slic/assets/12241059/f4518847-0826-4af4-ada6-1857b8904d3b)

`slic run` (I don't have any tests written for the test plugin, which is why causing an additional error message - 
![image](https://github.com/stellarwp/slic/assets/12241059/01686912-2d67-4244-b7f2-c816e6691f62)

Video - 
[Slic_Linux_Artifact.webm](https://github.com/stellarwp/slic/assets/12241059/fe19efea-4ed3-416d-a60e-0515510cb560)


How I fixed original issue - 
---

I managed to resolve the issue I was facing with Docker on Linux, I found the root of the issue to be user and group ID was being incorrectly set to 100999. This was similar to a problem I had encountered while using Lando and Docker before. To fix it, I took the following steps:

1. Uninstall Docker: I completely removed Docker from the system.
2. Reinstall Docker via Snap: I reinstalled Docker using Snap (Instead of directly from the Docker Website) , following the guidelines provided in this [Snapcraft Docker documentation](https://snapcraft.io/docker).
3. System Restart: After reinstalling Docker, I restarted my computer to ensure all changes took effect.
4. Cleanup Slic Directories: I deleted the _wordpress directory in Slic and corrected the permissions (from 100999 to my user) in my Plugin directory.
5. Setup/Enable Slic: I ran:
`slic down && slic up && slic run`

After performing these steps, everything started working as expected.
Reference Links
[Docker Desktop Linux Issue #31: Container generated files gets wrong uid & gid on host machine](https://github.com/docker/desktop-linux/issues/31)
[Lando Issue #3343: Rootless Docker: file ownership changes](https://github.com/lando/lando/issues/3343)