### PR TITLE
Add shm_size param to chrome container

### DIFF
--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -131,6 +131,7 @@ services:
       interval: 1s
       timeout: 3s
       retries: 30
+    shm_size: "${SLIC_CHROME_CONTAINER_SHM_SIZE:-256m}"
 
   slic:
     image: ghcr.io/stellarwp/slic-php${SLIC_PHP_VERSION}:${SLIC_VERSION}


### PR DESCRIPTION
I kept getting invalid session ID errors when running Codeception acceptance JS tests. After searching for some answers, the chrome container turns out doesn't have enough shm size. When I set it in `slic-stack.yml`, the tests went through successfully.

The config allows users to set the value in a `.env.slic.local` file. The default value `256m` the minimum value the tests went through successfully based on my tests. I tried `128m` but it still got the errors.

Can you please let me know your thoughts?

Here is my codeception `acceptancejs.suite.yml` file for reference:

```
actor: AcceptanceJsTester
bootstrap: _bootstrap.php
step_decorators:
  - \Codeception\Step\AsJson
modules:
  enabled:
    - WPLoader
    - WPDb
    - WPWebDriver
    - \Helper\AcceptanceJs
  config:
    WPDb:
      dsn: "mysql:host=%WP_DB_HOST%;dbname=%WP_DB_NAME%"
      user: "%WP_DB_USER%"
      password: "%WP_DB_PASSWORD%"
      dump: tests/_data/dump.sql
      populate: true
      cleanup: true
      url: "%WP_URL%"
      tablePrefix: "%WP_TABLE_PREFIX%"
    WPLoader:
      loadOnly: true,
      wpRootFolder: "%WP_ROOT_FOLDER%"
      dbName: "%WP_DB_NAME%"
      dbHost: "%WP_DB_HOST%"
      dbUser: "%WP_DB_USER%"
      dbPassword: "%WP_DB_PASSWORD%"
    WPWebDriver:
      # We have to use a URL Chromedriver will be able to resolve.
      # See the `.env.dist` file for more information.
      url: "%WP_CHROMEDRIVER_URL%"
      # see codeception.dist.yml for the configuration
      adminUsername: "%WP_ADMIN_USERNAME%"
      adminPassword: "%WP_ADMIN_PASSWORD%"
      adminPath: "/wp-admin"
      browser: chrome
      host: "%CHROMEDRIVER_HOST%"
      port: "%CHROMEDRIVER_PORT%"
      window_size: false
      capabilities:
        chromeOptions:
          args:
            [
              "--headless",
              "--disable-gpu",
              "--proxy-server='direct://'",
              "--proxy-bypass-list=*",
              "--url-base=/wd/hub",
              "--no-sandbox",
              "--disable-dev-shm-usage"
            ]
```