### PR TITLE
feat(slic-stack.yml) control the WP_HTTP_BLOCK_EXTERNAL const

### DIFF
--- a/.env.slic
+++ b/.env.slic
@@ -77,3 +77,7 @@ WORDPRESS_HTTP_PORT=8888
 
 # Directory the host machine's cache directory will be mapped to.
 COMPOSER_CACHE_DIR=./.cache
+
+# This value will be assigned to the WP_HTTP_BLOCK_EXTERNAL constant defined in the wp-config.php file.
+# Set to `true` to block all external HTTP requests from WordPress, set to `false` to allow all requests.
+SLIC_WP_HTTP_BLOCK_EXTERNAL=true

--- a/.env.slic
+++ b/.env.slic
@@ -81,3 +81,7 @@ COMPOSER_CACHE_DIR=./.cache
 # This value will be assigned to the WP_HTTP_BLOCK_EXTERNAL constant defined in the wp-config.php file.
 # Set to `true` to block all external HTTP requests from WordPress, set to `false` to allow all requests.
 SLIC_WP_HTTP_BLOCK_EXTERNAL=true
+
+# This value will be assigned to the DISABLE_WP_CRON constant defined in the wp-config.php file.
+# Set to `true` to disable the WordPress cron system, set to `false` to enable it.
+SLIC_DISABLE_WP_CRON=true

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -90,7 +90,7 @@ services:
         define( 'WP_DEBUG_DISPLAY', true );
         define( 'WP_DEBUG_LOG', true );
         define( 'DISABLE_WP_CRON', true );
-        define( 'WP_HTTP_BLOCK_EXTERNAL', true );
+        define( 'WP_HTTP_BLOCK_EXTERNAL', ${SLIC_WP_HTTP_BLOCK_EXTERNAL:-true} );
       # Configure this to debug the tests with XDebug.
       # Map the `_wordpress` directory to `/var/www/html' directory in your IDE of choice.
       # Map the `_plugins` directory to `/plugins` directory in your IDE of choice.

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -89,7 +89,7 @@ services:
         define( 'TRIBE_NO_FREEMIUS', true );
         define( 'WP_DEBUG_DISPLAY', true );
         define( 'WP_DEBUG_LOG', true );
-        define( 'DISABLE_WP_CRON', true );
+        define( 'DISABLE_WP_CRON', ${SLIC_DISABLE_WP_CRON:-true} );
         define( 'WP_HTTP_BLOCK_EXTERNAL', ${SLIC_WP_HTTP_BLOCK_EXTERNAL:-true} );
       # Configure this to debug the tests with XDebug.
       # Map the `_wordpress` directory to `/var/www/html' directory in your IDE of choice.


### PR DESCRIPTION
Use the SLIC_WP_HTTP_BLOCK_EXTERNAL env var.

By default `slic` will set up the embedded WordPress installation to block all outgoing HTTP requests using the `WP_HTTP_BLOCK_EXTERNAL` constant.

In some instances this might cause issues with projects that need to call outside APIs to work.

This PR explores the possibility of controlling that constant value using the `SLIC_WP_HTTP_BLOCK_EXTERNAL` env var.

Similarly, this PR introduces control, via the `.env.slic.run` file, for the `DISABLE_WP_CRON` constant defined in the `wp-config.php` file.