### PR TITLE
Remove version from docker compose yaml files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.5.2] - 2024-04-04
+* Change - Remove `version` property from docker compose .yml files as it's obsolete since v2.25. https://github.com/docker/compose/issues/11628 
+
 # [1.5.1] - 2024-01-05
 * Change - Update the `npm` version to `18.13.0`
 * Change - Update the `nvm` version to `v0.39.7`

--- a/slic-stack.site.yml
+++ b/slic-stack.site.yml
@@ -1,7 +1,5 @@
 # docker compose configuration file used to run cross-activation tests.
 
-version: "3"
-
 services:
 
   wordpress:

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -1,7 +1,5 @@
 # docker compose configuration file used to run cross-activation tests.
 
-version: "3.9"
-
 networks:
   slic:
 


### PR DESCRIPTION
Using the latest docker compose v2 (and since v2.25), it shows warnings like:

```
[debug] Executing command: XDH=host.docker.internal docker compose -f "/home/xxxx/projects/slic/slic-stack.yml" ps --services --filter "status=running"

WARN[0000] /home/xxxx/projects/slic/slic-stack.yml: `version` is obsolete 
````

This removes the version from those files and removes the warning for me.

More info:
- https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements
- https://github.com/docker/compose/issues/11628