### PR TITLE
Build multi-platform images

### DIFF
--- a/.github/workflows/publish-slic-docker-image.yml
+++ b/.github/workflows/publish-slic-docker-image.yml
@@ -74,3 +74,4 @@ jobs:
             PHP_VERSION=${{ matrix.php_version }}
             NODE_VERSION=18.13.0
             NVM_VERSION=v0.39.7
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -74,3 +74,4 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             WP_VERSION=${{ matrix.wp_version }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This PR updates the build workflows to make sure the images will be built in the `linux/amd64` version, used on x86 machines, and the `linux/arm64` one, used by ARM processors (e.g. Apple Silicon).
