### PR TITLE
Build X86 and ARM versions of the images

### DIFF
--- a/.github/workflows/publish-slic-docker-image.yml
+++ b/.github/workflows/publish-slic-docker-image.yml
@@ -74,3 +74,4 @@ jobs:
             PHP_VERSION=${{ matrix.php_version }}
             NODE_VERSION=18.13.0
             NVM_VERSION=v0.39.7
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -74,3 +74,4 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             WP_VERSION=${{ matrix.wp_version }}
+          platforms: linux/amd64,linux/arm64

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.5.3] - 2024-04-05
+* Change - Build `linux/arm64` images for the `slic` and `wordpress` containers to avoid issues when running `slic` on ARM machines.
+
 # [1.5.2] - 2024-04-04
 * Change - Remove `version` property from docker compose .yml files as it's obsolete since v2.25. https://github.com/docker/compose/issues/11628 
 

--- a/slic.php
+++ b/slic.php
@@ -33,7 +33,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.5.2';
+const CLI_VERSION = '1.5.3';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
Modify the build workflows to build `linux/amd64` (x86) and `linux/arm64` versions of the `slic` and `wordpress` images.

When running `slic upgrade` on machines using latest versions of Docker on ARM machine (e.g. MacOS on Apple Silicon or Asahi Linux on Apple Silicon), the operation would fail lamentin lack of an ARM version for the images:

* [before](https://share.cleanshot.com/ZznsD3tS)
* [after](https://share.cleanshot.com/J4jdr1Mt)

This update to the workflows will build both versions making it possible to run `slic` on all machines.
