### PR TITLE
Disable WP automatic updating out of the box

### DIFF
--- a/.env.slic
+++ b/.env.slic
@@ -85,3 +85,11 @@ SLIC_WP_HTTP_BLOCK_EXTERNAL=true
 # This value will be assigned to the DISABLE_WP_CRON constant defined in the wp-config.php file.
 # Set to `true` to disable the WordPress cron system, set to `false` to enable it.
 SLIC_DISABLE_WP_CRON=true
+
+# This value will be assigned to the WP_AUTO_UPDATE_CORE constant defined in the wp-config.php file.
+# Set to `true` to allow automatic core updates to take place.
+SLIC_WP_AUTO_UPDATE_CORE=false
+
+# This value will be assigned to the AUTOMATIC_UPDATER_DISABLED constant defined in the wp-config.php file.
+# Set to `false` to allow all types of automatic updates.
+SLIC_AUTOMATIC_UPDATER_DISABLED=true

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.5.4] - 2024-04-05
+* Change - Disable WordPress's automatic updating in slic containers via docker compose. See comments in .env.slic to customize this behavior.
+
 # [1.5.3] - 2024-04-05
 * Change - Build `linux/arm64` images for the `slic` and `wordpress` containers to avoid issues when running `slic` on ARM machines.
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [1.5.4] - 2024-04-05
-* Change - Disable WordPress's automatic updating in slic containers via docker compose. See comments in .env.slic to customize this behavior.
+* Change - Disable WordPress's automatic updating in slic containers via docker compose `WORDPRESS_CONFIG_EXTRA` defines. See comments in .env.slic to customize this behavior.
 
 # [1.5.3] - 2024-04-05
 * Change - Build `linux/arm64` images for the `slic` and `wordpress` containers to avoid issues when running `slic` on ARM machines.

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -89,6 +89,8 @@ services:
         define( 'WP_DEBUG_LOG', true );
         define( 'DISABLE_WP_CRON', ${SLIC_DISABLE_WP_CRON:-true} );
         define( 'WP_HTTP_BLOCK_EXTERNAL', ${SLIC_WP_HTTP_BLOCK_EXTERNAL:-true} );
+        define( 'WP_AUTO_UPDATE_CORE', ${SLIC_WP_AUTO_UPDATE_CORE:-false} );
+        define( 'AUTOMATIC_UPDATER_DISABLED', ${SLIC_AUTOMATIC_UPDATER_DISABLED:-true} );
       # Configure this to debug the tests with XDebug.
       # Map the `_wordpress` directory to `/var/www/html' directory in your IDE of choice.
       # Map the `_plugins` directory to `/plugins` directory in your IDE of choice.


### PR DESCRIPTION
I was building a script that would change the WP version installed with `slic wp core update --force --version=6.4.1` and every other time running `slic wp core version` would show `6.5` so, I can only assume that WordPress is somehow updating it automatically behind the scenes when wp cli commands being run.

This disables that functionality out of the box.

Ref: https://developer.wordpress.org/advanced-administration/upgrade/upgrading/#update-configuration