### PR TITLE
Better airplane mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.6.1] - 2024-04-19
+* Change - the `airplane-mode` command now installs the plugin in the must-use plugins directory instead of the plugins directory.
+* Fixed - `.bat` file now uses the correct path to the `slic` executable on Windows.
+
 # [1.6.0] - 2024-04-10
 * Added - The `slic update-dump` command to update a dump file for the current project, with an optional WordPress version update, e.g. `slic update-dump tests/_data/dump.sql latest`. 
 

--- a/slic.bat
+++ b/slic.bat
@@ -4,4 +4,4 @@ if "%PHP_PEAR_PHP_BIN%" neq "" (
 	set PHPBIN=%PHP_PEAR_PHP_BIN%
 ) else set PHPBIN=php
 
-"%PHPBIN%" "slic" %*
+"%PHPBIN%" "%~dp0\slic.php" %*

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.6.0';
+const CLI_VERSION = '1.6.1';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/src/commands/airplane-mode.php
+++ b/src/commands/airplane-mode.php
@@ -42,8 +42,19 @@ $activate = $toggle === 'on';
 setup_id();
 ensure_wordpress_ready();
 
-$ensure_airplane_mode_plugin = static function () {
-	$plugin_dir = slic_plugins_dir( 'airplane-mode' );
+$ensure_airplane_mode_plugin_present = static function () {
+	$mu_plugins_dir = slic_mu_plugins_dir();
+	$plugin_dir     = $mu_plugins_dir . DIRECTORY_SEPARATOR . 'airplane-mode';
+
+	if (
+		! is_dir( dirname( $mu_plugins_dir ) )
+		&& ! mkdir( $concurrentDirectory = dirname( $mu_plugins_dir ), 0755, true )
+		&& ! is_dir( $concurrentDirectory )
+	) {
+		echo magenta( "Failed to create mu-plugins directory {$mu_plugins_dir}." );
+		exit( 1 );
+	}
+
 	if ( ! is_dir( $plugin_dir ) ) {
 		$cloned = process_realtime( 'git clone https://github.com/norcross/airplane-mode ' . $plugin_dir );
 		if ( $cloned !== 0 ) {
@@ -51,19 +62,51 @@ $ensure_airplane_mode_plugin = static function () {
 			exit( 1 );
 		}
 	}
+
+	if (
+		is_file( $mu_plugins_dir . DIRECTORY_SEPARATOR . 'airplane-mode.php' )
+		&& ! unlink( $mu_plugins_dir . DIRECTORY_SEPARATOR . 'airplane-mode.php' )
+	) {
+		echo magenta( "Failed to remove the airplane-mode plugin." );
+		exit( 1 );
+	}
+
+	$loader_code = <<< PHP
+<?php
+
+require_once __DIR__ . '/airplane-mode/airplane-mode.php';
+PHP;
+
+	if ( ! file_put_contents( $mu_plugins_dir . DIRECTORY_SEPARATOR . 'airplane-mode.php', $loader_code, LOCK_EX ) ) {
+		echo magenta( "Failed to write the airplane-mode plugin." );
+		exit( 1 );
+	}
 };
 
-check_status_or(
-	slic_process()( cli_command( [ 'plugin', 'is-installed', 'airplane-mode' ] ) ),
-	$ensure_airplane_mode_plugin
-);
+$ensure_airplane_mode_plugin_removed = static function(){
+	$mu_plugins_dir = slic_mu_plugins_dir();
+	$plugin_dir     = $mu_plugins_dir . DIRECTORY_SEPARATOR . 'airplane-mode';
+
+	if ( is_dir( $plugin_dir ) && ! rrmdir( $plugin_dir ) ) {
+		echo magenta( "Failed to remove the airplane-mode plugin." );
+		exit( 1 );
+	}
+
+	if (
+		is_file( $mu_plugins_dir . DIRECTORY_SEPARATOR . 'airplane-mode.php' )
+		&& ! unlink( $mu_plugins_dir . DIRECTORY_SEPARATOR . 'airplane-mode.php' )
+	) {
+		echo magenta( "Failed to remove the airplane-mode plugin." );
+		exit( 1 );
+	}
+};
 
 if ( $activate ) {
-	echo "Activating the airplane-mode plugin..." . PHP_EOL;
-	check_status_or_exit( slic_process()( cli_command( [ 'plugin', 'activate', 'airplane-mode' ] ) ) );
-	echo light_cyan( 'Airplane mode plugin activated: all external data calls are now disabled.' );
+	echo "Installing airplane-mode plugin in the must-use plugins directory..." . PHP_EOL;
+	$ensure_airplane_mode_plugin_present();
+	echo light_cyan( 'Airplane mode plugin installed: all external data calls are now disabled.' );
 } else {
-	echo "Deactivating the airplane-mode plugin..." . PHP_EOL;
-	check_status_or_exit( slic_process()( cli_command( [ 'plugin', 'deactivate', 'airplane-mode' ] ) ) );
-	echo light_cyan( 'Airplane mode plugin deactivated: external data calls are now enabled.' );
+	echo "Removing the airplane-mode plugin from the must-use plugins directory..." . PHP_EOL;
+	$ensure_airplane_mode_plugin_removed();
+	echo light_cyan( 'Airplane mode plugin removed: external data calls are now enabled.' );
 }

--- a/src/slic.php
+++ b/src/slic.php
@@ -460,6 +460,19 @@ function slic_themes_dir( $path = '' ) {
 }
 
 /**
+ * Returns the absolute path to the current mu-plugins directory slic is using.
+ *
+ * @since TBD
+ *
+ * @param string $path An optional path to append to the current slic mu-plugins directory.
+ *
+ * @return string The absolute path to the current mu-plugins directory slic is using.
+ */
+function slic_mu_plugins_dir( $path = '' ) {
+	return slic_content_type_dir( 'mu-plugins', $path );
+}
+
+/**
  * Returns the absolute path to the current content directory slic is using.
  *
  * @param string $path An optional path to append to the current slic content directory.
@@ -475,6 +488,8 @@ function slic_content_type_dir( $content_type = 'plugins', $path = '' ) {
 		$default_path = '/_plugins';
 	} elseif ( 'themes' === $content_type ) {
 		$default_path = '/_wordpress/wp-content/themes';
+	} elseif ( 'mu-plugins' === $content_type ) {
+		$default_path = '/_wordpress/wp-content/mu-plugins';
 	}
 
 	if ( empty( $content_type_dir ) ) {


### PR DESCRIPTION
This PR was born in the context of an exploration of a bug on one of the plugins where end-to-end tests would keep failing at random due to WordPress attempting remote-updates and failing.

The PR changes the behaviour of the `airplane-mode` command:
* `slic airplane-mode on` will clone and set up the `norcross/airplane-mode` plugin in the mu-plugins directory, including the plugin loader.
* `slic airplane-mode off` will remove the plugin and the loader from the `mu-plugins` directory.

The idea would be to enable the use of the `slic airplane-mode on` call in CI envs.

Smaller bonus, fix to the `.bat` file to make sure `slic` will be correctly pointed out on Windows.
