### PR TITLE
Playwright support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.6.3] - 2024-05-10
+* Added - The `playwright` command to Playwright commands in the stack.
+* Added - The `less` binary to the `slic` container (to correctly format wp-cli output).
+* Added - The `p` alias to the `slic` container to allow running Playwright commands with `p <command>`, similar to `c <command>` to run Codeception commands.
+
 # [1.6.2] - 2024-05-10
 * Added - The `slic` command now loads the `.env.slic.local` file from the target directory if it exists. (thanks @cliffordp)
 * Added - The `chrome` container shm size is now set to `256m` by default, and is controllable via the `SLIC_CHROME_CONTAINER_SHM_SIZE` env var. (thanks @maurisrx)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.6.2] - 2024-05-10
+* Added - The `slic` command now loads the `.env.slic.local` file from the target directory if it exists. (thanks @cliffordp)
+* Added - The `chrome` container shm size is now set to `256m` by default, and is controllable via the `SLIC_CHROME_CONTAINER_SHM_SIZE` env var. (thanks @maurisrx)
+
 # [1.6.1] - 2024-04-19
 * Change - the `airplane-mode` command now installs the plugin in the must-use plugins directory instead of the plugins directory.
 * Fixed - `.bat` file now uses the correct path to the `slic` executable on Windows.

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get upgrade -yqq && apt-get install -yqq --no-install-
     libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
     libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
     libxdamage1 libxext6 libxfixes3 libxrandr2 libgbm1 \
-    libpango-1.0-0 libcairo2 libasound2 \
+    libpango-1.0-0 libcairo2 libasound2 less \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Configure the uopz extension.

--- a/containers/slic/bashrc_scripts.sh
+++ b/containers/slic/bashrc_scripts.sh
@@ -1,6 +1,7 @@
 # Some aliases to save some typing.
 alias c="vendor/bin/codecept -c $(if [ -f 'codeception.slic.yml' ]; then echo 'codeception.slic.yml'; else echo 'codeception.tric.yml'; fi)"
 alias cr="vendor/bin/codecept -c $(if [ -f 'codeception.slic.yml' ]; then echo 'codeception.slic.yml'; else echo 'codeception.tric.yml'; fi) run"
+alias p="node_modules/.bin/playwright"
 
 # Returns the path to the PHP version configuration file.
 function xdebug_config_file(){
@@ -32,6 +33,7 @@ fi
 
 echo "  c    = codecept"
 echo "  cr   = codecept run"
+echo "  p    = playwright"
 echo "  xon  = turn xdebug on"
 echo "  xoff = turn xdebug off"
 echo ""

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.6.1';
+const CLI_VERSION = '1.6.2';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/slic.php
+++ b/slic.php
@@ -80,6 +80,7 @@ Available commands:
   <light_cyan>using</light_cyan>          Returns the current <light_cyan>use</light_cyan> target.
   <light_cyan>wp</light_cyan>             Runs a wp-cli command or opens a `wp-cli shell` in the stack.
   <light_cyan>xdebug</light_cyan>         Activates and deactivates XDebug in the stack, returns the current XDebug status or sets its values.
+  <light_cyan>playwright</light_cyan>     Runs Playwright commands in the stack.
 
 Type <light_cyan>{$cli_name} <command> help</light_cyan> for info about each command.
 HELP;

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.6.2';
+const CLI_VERSION = '1.6.3';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/src/commands/npm.php
+++ b/src/commands/npm.php
@@ -6,8 +6,6 @@ if ( $is_help ) {
 	$help = <<< HELP
 	SUMMARY:
 
-		Runs an npm command in the stack. If an .nvmrc is present, that version of node will be used.
-
 		This command requires a use target set using the <light_cyan>use</light_cyan> command.
 
 	USAGE:

--- a/src/commands/playwright.php
+++ b/src/commands/playwright.php
@@ -13,9 +13,7 @@ if ( $is_help ) {
 	$help = <<< HELP
 	SUMMARY:
 
-		Runs Playwright commands in the stack.
-		This command will not set up Playwright and its dependencies.
-		If Playwright is not already configured, run the <light_cyan>{$cli_name} playwright install</light_cyan> first.
+		This command requires a use target set using the <light_cyan>use</light_cyan> command.
 
 	USAGE:
 

--- a/src/commands/playwright.php
+++ b/src/commands/playwright.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Handles Playwright commands.
+ *
+ * @var bool    $is_help  Whether we're handling an `help` request on this command or not.
+ * @var Closure $args     The argument map closure, as produced by the `args` function.
+ * @var string  $cli_name The current name of the `slic` CLI application.
+ */
+
+namespace StellarWP\Slic;
+
+if ( $is_help ) {
+	$help = <<< HELP
+	SUMMARY:
+
+		Runs Playwright commands in the stack.
+		This command will not set up Playwright and its dependencies.
+		If Playwright is not already configured, run the <light_cyan>{$cli_name} playwright install</light_cyan> first.
+
+	USAGE:
+
+		<yellow>{$cli_name} playwright [...<commands>]</yellow>
+
+	EXAMPLES:
+
+		<light_cyan>{$cli_name} playwright install</light_cyan>
+		Install Playwright dependencies in the current <light_cyan>use</light_cyan> target.
+
+		<light_cyan>{$cli_name} playwright test</light_cyan>
+		Run all Playwright tests following the Playwright configuration in the current <light_cyan>use</light_cyan> target.
+
+		<light_cyan>{$cli_name} playwright test tests/e2e/my-test.spec.ts</light_cyan>
+		Run a specific Playwright test file from the root directory of the <light_cyan>use</light_cyan> target.
+
+	HELP;
+
+	echo colorize( $help );
+
+	return;
+}
+
+$using = slic_target_or_fail();
+echo light_cyan( "Using {$using}" . PHP_EOL );
+
+ensure_service_running( 'slic' );
+
+setup_id();
+$playwright_args = $args( '...' );
+$status          = slic_realtime()(
+	array_merge(
+		[
+			'exec',
+			'--user',
+			sprintf( '"%s:%s"', getenv( 'SLIC_UID' ), getenv( 'SLIC_GID' ) ),
+			'--workdir',
+			escapeshellarg( get_project_container_path() ),
+			'slic',
+			'node_modules/.bin/playwright',
+		],
+		$playwright_args
+	)
+);
+
+// If there is a status other than 0, we have an error. Bail.
+if ( $status ) {
+	exit( $status );
+}
+
+exit( $status );


### PR DESCRIPTION
This PR adds the `playwright` command to allow interacting with the `node_modules/.bin/playwright` binary in the `slic` container.
The command will **not** deal with requiring or installing Playwright or its dependencies, but will add a `p` alias in the stack.

E.g. to set up Playwright from scratch in a project:

```bash
slic npm init playwright@latest
slic playwright install chromium
slic playwright test
```

The same could be done from within ` slic shell`:
```
$ npm init playwright@latest
$ p install chromium
$ p test
```

Finally, the PR adds the `less` binary to the `slic` container to allow for complete output of `wp <command> --help`.