### PR TITLE
Bugfix: Properly restarts the PHP services after using the `slic php-version set` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased - 2024-05-27
+* Fixed - Properly read changes and restart stack after using the `slic php-version set` command.
+
 # [1.6.3] - 2024-05-10
 * Added - The `playwright` command to Playwright commands in the stack.
 * Added - The `less` binary to the `slic` container (to correctly format wp-cli output).

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased - 2024-05-27
+# [Unreleased] - 2024-05-27
 * Fixed - Properly read changes and restart stack after using the `slic php-version set` command.
 
 # [1.6.3] - 2024-05-10

--- a/src/commands/php-version.php
+++ b/src/commands/php-version.php
@@ -57,12 +57,12 @@ if ( in_array( $sub_command, [ 'set', 'reset' ] ) ) {
             if ( ! $skip_rebuild ) {
                 $confirm = ask("Do you want to restart the stack now? ", 'yes');
 
-                if ( $confirm ) {
-                    rebuild_stack();
-                    update_stack_images();
-	                load_env_file( root() . '/.env.slic.run' );
-	                restart_php_services( true );
-                }
+	            if ( $confirm ) {
+		            rebuild_stack();
+		            update_stack_images();
+		            load_env_file( root() . '/.env.slic.run' );
+		            restart_php_services( true );
+	            }
             }
 
 			exit( 0 );

--- a/src/commands/php-version.php
+++ b/src/commands/php-version.php
@@ -60,6 +60,8 @@ if ( in_array( $sub_command, [ 'set', 'reset' ] ) ) {
                 if ( $confirm ) {
                     rebuild_stack();
                     update_stack_images();
+	                load_env_file( root() . '/.env.slic.run' );
+	                restart_php_services( true );
                 }
             }
 


### PR DESCRIPTION
### Main Changes
- Properly restarts the PHP services after using the `slic php-version set` command.
- Adds a `restart_services()` function to perform restart/destroy functionality concurrently instead of synchronously. 