### PR TITLE
Feature: Add PHP 8.3 Docker Images

### DIFF
--- a/.github/workflows/publish-slic-docker-image.yml
+++ b/.github/workflows/publish-slic-docker-image.yml
@@ -17,30 +17,20 @@ jobs:
     strategy:
       matrix:
         # The php_version is the docker tag from https://hub.docker.com/_/php/tags
-        include:
-          - image_suffix: '7.3'
-            php_version: '7.3.33'
-          - image_suffix: '7.4'
-            php_version: '7.4.33'
-          - image_suffix: '8.0'
-            php_version: '8.0.28'
-          - image_suffix: '8.1'
-            php_version: '8.1.16'
-          - image_suffix: '8.2'
-            php_version: '8.2.3'
+        php_version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -48,9 +38,9 @@ jobs:
 
       - name: Extract metadata for image
         id: meta
-        uses: docker/metadata-action@v4.3.0
+        uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}-php${{ matrix.image_suffix }}
+          images: ghcr.io/${{ github.repository }}-php${{ matrix.php_version }}
           tags: |
             type=edge,branch=main
             type=ref,event=branch
@@ -60,7 +50,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3.3.1
+        uses: docker/build-push-action@v3
         with:
           context: containers/slic
           file: containers/slic/Dockerfile

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -20,26 +20,29 @@ jobs:
         php_version: [ '8.0', '8.1', '8.2' ]
         include:
           # No WordPress image for version 6.2+ and PHP 7.3: use the latest 5.9 version.
-          # This version is NOT udpated in the containers/wordpress/Dockerfile for back-compatibility.
+          # This version is NOT updated in the containers/wordpress/Dockerfile for back-compatibility.
           - wp_version: '5.9'
             php_version: '7.3'
           # No WordPress image for version 6.2+ and PHP 7.4: use the latest 6.1.1 version.
           # See containers/wordpress/Dockerfile for the wp-cli update to version 6.2.
           - wp_version: '6.1.1'
             php_version: '7.4'
+          # Use the latest 6.5 WordPress version for PHP 8.3
+          - wp_version: '6.5'
+            php_version: '8.3'
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -47,7 +50,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4.3.0
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}-wordpress-php${{ matrix.php_version }}
           tags: |
@@ -56,10 +59,10 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{raw}}
 
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3.3.1
+        uses: docker/build-push-action@v5
         continue-on-error: true
         with:
           context: containers/wordpress

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -27,7 +27,7 @@ jobs:
           # See containers/wordpress/Dockerfile for the wp-cli update to version 6.2.
           - wp_version: '6.1.1'
             php_version: '7.4'
-          # Use the latest 6.5 WordPress version for PHP 8.3
+          # Use the latest 6.5 WordPress version for PHP 8.3.
           - wp_version: '6.5'
             php_version: '8.3'
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased] - 2024-05-27
+* Change - Add PHP 8.3 docker images.
+* Change - Update GitHub action versions to remove node notices.
+* Change - Build slic images from the latest PHP minor versions.
+
 # [1.6.3] - 2024-05-10
 * Added - The `playwright` command to Playwright commands in the stack.
 * Added - The `less` binary to the `slic` container (to correctly format wp-cli output).

--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased] - 2024-05-27
-* Change - Add PHP 8.3 docker images.
+* Added - PHP 8.3 docker images.
 * Change - Update GitHub action versions to remove node notices.
-* Change - Build slic images from the latest PHP minor versions.
+* Change - Build slic images from the latest PHP patch versions.
 
 # [1.6.3] - 2024-05-10
 * Added - The `playwright` command to Playwright commands in the stack.

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.4.33
+ARG PHP_VERSION=7.4
 
 # Source Composer 1 and 2 from the respective images, multi-layer builds.
 FROM composer:1 AS composer1


### PR DESCRIPTION
### Main Changes
- Adds PHP 8.3 docker images for slic and WordPress.
- Updates all GitHub actions to remove deprecated nodejs warnings.
- All docker images are now built from their latest PATCH version, e.g. using a docker hub tag of `8.2` will use the latest PHP 8.2.X version to build from.