### PR TITLE
Use a volume for php.ini, fix opcache in containers

### DIFF
--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -40,9 +40,6 @@ RUN apt-get update && apt-get upgrade -yqq && apt-get install -yqq --no-install-
 # Configure the uopz extension.
 COPY ./docker-php-ext-uopz.ini /usr/local/etc/php/conf.d/docker-php-ext-uopz.ini
 
-# Use our own ini configuration file to set up some PHP default.
-COPY ./php.ini /usr/local/etc/php/conf.d/999-slic.ini
-
 # Add the XDebug control scripts.
 COPY ./xdebug-on.sh /usr/local/bin/xdebug-on
 COPY ./xdebug-off.sh /usr/local/bin/xdebug-off

--- a/containers/slic/php.ini
+++ b/containers/slic/php.ini
@@ -26,3 +26,8 @@ opcache.use_cwd=0
 opcache.enable_file_override=1
 opcache.file_update_protection=0
 opcache.revalidate_freq=0
+opcache.validate_timestamps=1
+opcache.max_accelerated_files=25000
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=16
+

--- a/containers/slic/php.ini
+++ b/containers/slic/php.ini
@@ -22,9 +22,6 @@ xdebug.discover_client_host=1
 xdebug.log_level=0
 
 ; Opcache
-opcache.use_cwd=0
-opcache.enable_file_override=1
-opcache.file_update_protection=0
 opcache.revalidate_freq=0
 opcache.validate_timestamps=1
 opcache.max_accelerated_files=25000

--- a/containers/slic/php.ini
+++ b/containers/slic/php.ini
@@ -20,3 +20,9 @@ xdebug.start_with_request=yes
 xdebug.mode=develop,debug,coverage
 xdebug.discover_client_host=1
 xdebug.log_level=0
+
+; Opcache
+opcache.use_cwd=0
+opcache.enable_file_override=1
+opcache.file_update_protection=0
+opcache.revalidate_freq=0

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -11,8 +11,6 @@ RUN chmod a+x /usr/local/bin/xdebug-on && \
     chmod a+x /usr/local/bin/xdebug-off && \
     xdebug-off
 RUN chmod -R a+rwx /usr/local/etc/php/conf.d
-# Use our own ini configuration file to set up some PHP default.
-COPY ./php.ini /usr/local/etc/php/conf.d/999-slic.ini
 
 # Install and make wp-cli binary available and executable by all users.
 ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp

--- a/containers/wordpress/php.ini
+++ b/containers/wordpress/php.ini
@@ -22,9 +22,6 @@ xdebug.discover_client_host=1
 xdebug.log_level=0
 
 ; Opcache
-opcache.use_cwd=0
-opcache.enable_file_override=1
-opcache.file_update_protection=0
 opcache.revalidate_freq=0
 opcache.validate_timestamps=1
 opcache.max_accelerated_files=25000

--- a/containers/wordpress/php.ini
+++ b/containers/wordpress/php.ini
@@ -20,3 +20,9 @@ xdebug.start_with_request=yes
 xdebug.mode=develop,debug,coverage
 xdebug.discover_client_host=1
 xdebug.log_level=0
+
+; Opcache
+opcache.use_cwd=0
+opcache.enable_file_override=1
+opcache.file_update_protection=0
+opcache.revalidate_freq=0

--- a/containers/wordpress/php.ini
+++ b/containers/wordpress/php.ini
@@ -26,3 +26,7 @@ opcache.use_cwd=0
 opcache.enable_file_override=1
 opcache.file_update_protection=0
 opcache.revalidate_freq=0
+opcache.validate_timestamps=1
+opcache.max_accelerated_files=25000
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=16

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -108,6 +108,7 @@ services:
       - ${SLIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins
       - ${SLIC_THEMES_DIR}:/var/www/html/wp-content/themes
       - ${COMPOSER_CACHE_DIR:-./.cache}:/composer-cache
+      - ./containers/wordpress/php.ini:/usr/local/etc/php/conf.d/zz-docker.ini
     healthcheck: # Apache service should be running correctly.
       test: service apache2 status
       start_period: 5s
@@ -197,6 +198,8 @@ services:
       - ${COMPOSER_CACHE_DIR:-./.cache}:/composer-cache
       # Scripts volume
       - ${SLIC_SCRIPTS}:/slic-scripts
+      # Configurable php.ini volume
+      - ./containers/slic/php.ini:/usr/local/etc/php/conf.d/zz-docker.ini
     extra_hosts:
       # Set as host=host.docker.internal in src/slic.php on Linux for XDebug.
       - "${host:-host}:host-gateway"


### PR DESCRIPTION
### Main Changes
- Setting `opcache.revalidate_freq=0` which these containers set as 2 will resolve a lot of issues in End To End tests where file changes aren't reflected for 2 seconds and `sleep()` will no longer be needed.
- We now volume mount the `php.ini` file so we can debug things in real time, instead of copying it when the image is built.