### PR TITLE
Update node version to 18.17.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.8.0] - 2024-12-04
+- Updated the `node` version to `18.17.0`, this affects the `npm` command and any other command usin the `npm` container.
+
 # [1.7.2] - 2024-08-30
 * Fixed - Set the `opcache.revalidate_freq` to `0` in the `slic` and `wordpress` containers to avoid issues with cached files in tests.
 

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -6,8 +6,8 @@ FROM composer:2 AS composer2
 
 FROM php:${PHP_VERSION}
 
-ARG NODE_VERSION=18.13.0
-ARG NVM_VERSION=v0.39.7
+ARG NODE_VERSION=18.17.0
+ARG NVM_VERSION=v0.40.1
 # Disable AVIF for GD https://github.com/mlocati/docker-php-extension-installer#configuration
 ARG IPE_GD_WITHOUTAVIF=true
 


### PR DESCRIPTION
Following the work done in the plugins to use v18.17.0 of `node`, this updates the default node version to it.
