### PR TITLE
Allow exit within slic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ wp
 vendor
 .data
 .idea
+.vscode
 *.log
 local-config.php
 

--- a/slic.php
+++ b/slic.php
@@ -27,6 +27,9 @@ use function StellarWP\Slic\maybe_prompt_for_repo_update;
 use function StellarWP\Slic\maybe_prompt_for_stack_update;
 use function StellarWP\Slic\root;
 use function StellarWP\Slic\setup_slic_env;
+
+uopz_allow_exit( true );
+
 // Set up the argument parsing function.
 $args = args( [
 	'subcommand',


### PR DESCRIPTION
For php 8.1 cli the exit statements were not respected for me. It seems like the defaults uopz for exit was being used (just skipping exit, die) calls.

By forcefully calling uopz_allow_exit now everything works as expected.

I am leaving some images as "proof" of the issue being fixed. See in the first screenshot the output of the `var_dump`s and still the fatals and where they are triggered.

In the second screenshot you can see where these statements are located.

![image](https://github.com/user-attachments/assets/0d7919d0-23d0-4c7c-80d7-a493843a55b0)

line 32 is being executed but still line 38 is executed as well

![image](https://github.com/user-attachments/assets/3cd4799f-86e6-4394-9511-1c372cba0bef)


And finally a screenshot after the fix :D 

![image](https://github.com/user-attachments/assets/691ebdf3-f14d-4670-864c-acf21aff5365)

