### PR TITLE
Update chrome container versions

### DIFF
--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -132,7 +132,7 @@ services:
       interval: 1s
       timeout: 3s
       retries: 30
-    shm_size: "${SLIC_CHROME_CONTAINER_SHM_SIZE:-256m}"
+    shm_size: "${SLIC_CHROME_CONTAINER_SHM_SIZE:-512m}"
 
   slic:
     image: ghcr.io/stellarwp/slic-php${SLIC_PHP_VERSION}:${SLIC_VERSION}

--- a/src/slic.php
+++ b/src/slic.php
@@ -1642,10 +1642,10 @@ function is_arm64() {
 function setup_architecture_env() {
 	if ( is_arm64() ) {
 		putenv( 'SLIC_ARCHITECTURE=arm64' );
-		putenv( 'SLIC_CHROME_CONTAINER=seleniarm/standalone-chromium:4.1.2-20220227' );
+		putenv( 'SLIC_CHROME_CONTAINER=seleniarm/standalone-chromium:4.20.0-20240427' );
 	} else {
 		putenv( 'SLIC_ARCHITECTURE=x86' );
-		putenv( 'SLIC_CHROME_CONTAINER=selenium/standalone-chrome:3.141.59' );
+		putenv( 'SLIC_CHROME_CONTAINER=selenium/standalone-chrome:4.27.0-20241225' );
 	}
 }
 


### PR DESCRIPTION
I was writing acceptancejs tests, and bumped into it. There is a bug with the latest WP 6.7.1 version. I didn't check the 6.7.0, but it works well with 6.6.2.

The bug I had was related to the publish button on the post-editing screen. It stopped being visible with WP 6.6.7.

Here is the screenshot of how it looked.

![Learndash Core Tests AcceptanceJS AdminCourseCreationCest test can be created fail](https://github.com/user-attachments/assets/dbe0c897-d946-4643-b768-386e8e115c2c)

I checked the styles, and this looked suspicious (settings block with the "publish" button):

<img width="930" alt="Screenshot 2024-12-26 at 16 04 52" src="https://github.com/user-attachments/assets/fac6efb5-687f-40b4-a3ac-d55545c6ef88" />


I then checked the supported chrome version for the :has() CSS relational pseudo-class here https://caniuse.com/css-has and it turned out that the minimal supported version is 105 which was released on Aug 30, 2022. And the version we use on ARM is 4.1.2-20220227 (before Aug 30).

I tested the update locally on ARM architecture with `.env.slic.local` containing `SLIC_CHROME_CONTAINER=seleniarm/standalone-chromium:4.20.0-20240427` and tests work now.

Version updates for Chrome container images:

* Updated the ARM64 Chrome container image to version [4.20.0-20240427](https://hub.docker.com/layers/seleniarm/standalone-chromium/4.20.0-20240427/images/sha256-7c5ba31a5c7a815372e520a9b458fe062ae92d8a38d12de2db6353c37c9181b1) from `4.1.2-20220227`.
* Updated the x86 Chrome container image to version [4.27.0-20241225](https://hub.docker.com/layers/selenium/standalone-chrome/4.27.0-20241225/images/sha256-5b9c7c3f9d6df440eef5d0acdf94ce33c8273bea3889eb057178e1f2a7826b65) from `3.141.59`.