### PR TITLE
Add PHP 8.4 compatibility changes

### DIFF
--- a/src/process.php
+++ b/src/process.php
@@ -237,7 +237,7 @@ function check_status_or_wait( callable $process, $timeout = 10 ) {
  *
  * @return callable The process closure.
  */
-function check_status_or( callable $process, callable $else = null ) {
+function check_status_or( callable $process, callable $else ) {
 	if ( 0 !== (int) $process( 'status' ) ) {
 		$else( $process );
 	}

--- a/src/utils.php
+++ b/src/utils.php
@@ -5,6 +5,8 @@
 
 namespace StellarWP\Slic;
 
+use Closure;
+
 require_once __DIR__ . '/process.php';
 require_once __DIR__ . '/colors.php';
 
@@ -17,7 +19,7 @@ require_once __DIR__ . '/colors.php';
  * @param int               $offset Start reading arguments from this position, usually `1` for the main args and `0`
  *                                  when reading an array of sub-arguments.
  *
- * @return \Closure The arg fetching closure.
+ * @return Closure The arg fetching closure.
  */
 function args( array $map = [], array $source = null, $offset = 1 ) {
 	if ( null === $source ) {
@@ -365,7 +367,7 @@ function write_env_file( $file, array $lines = [], $update = false ) {
  *
  * @param string $file The path to the env file to parse.
  *
- * @return \Closure A closure that will take the `$key` and `$default` arguments to fetch a value read from the env
+ * @return Closure A closure that will take the `$key` and `$default` arguments to fetch a value read from the env
  *                  format file.
  */
 function env_file( $file ) {

--- a/src/utils.php
+++ b/src/utils.php
@@ -13,15 +13,15 @@ require_once __DIR__ . '/colors.php';
 /**
  * Curried argument fetcher to avoid global spamming.
  *
- * @param array<string>     $map    The list of arguments to fetch from `$argv`.
- * @param array<mixed>|null $source The arguments source array, if not specified, then the global `$argv` array will
- *                                  be used.
- * @param int               $offset Start reading arguments from this position, usually `1` for the main args and `0`
- *                                  when reading an array of sub-arguments.
+ * @param array<string> $map    The list of arguments to fetch from `$argv`.
+ * @param ?array<mixed> $source The arguments source array, if not specified, then the global `$argv` array will
+ *                              be used.
+ * @param int           $offset Start reading arguments from this position, usually `1` for the main args and `0`
+ *                              when reading an array of sub-arguments.
  *
  * @return Closure The arg fetching closure.
  */
-function args( array $map = [], array $source = null, $offset = 1 ) {
+function args( array $map = [], ?array $source = null, $offset = 1 ) {
 	if ( null === $source ) {
 		// If the source is not specified, then read the arguments from the global CLI arguments array.
 		global $argv;

--- a/src/utils.php
+++ b/src/utils.php
@@ -41,7 +41,7 @@ function args( array $map = [], ?array $source = null, $offset = 1 ) {
 			continue;
 		}
 
-		$full_map[ $key ] = isset( $source[ $position + $offset ] ) ? $source[ $position + $offset ] : null;
+		$full_map[ $key ] = $source[ $position + $offset ] ?? null;
 	}
 
 	return static function ( $key, $default = null ) use ( $full_map ) {

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -147,11 +147,9 @@ function ensure_wordpress_installed(): bool {
 /**
  * Ensure, failing if not possible, that WordPress is correctly set up, configured and installed.
  *
- * @param string|null $version The WordPress version to ensure the readiness of, `latest` if null.
- *
  * @return bool Always `true` to indicate success.
  */
-function ensure_wordpress_ready( string $version = null ): bool {
+function ensure_wordpress_ready(): bool {
 	ensure_services_running( [ 'slic', 'wordpress' ] );
 	ensure_wordpress_installed();
 


### PR DESCRIPTION
When running `slic` with PHP 8.4, I noticed the following notices:

```bash
❯ slic use the-events-calendar 

Deprecated: StellarWP\Slic\args(): Implicitly marking parameter $source as nullable is deprecated, the explicit nullable type must be used instead in /Users/jpry/projects/slic/src/utils.php on line 22

Call Stack:
    0.0001     398368   1. {main}() /Users/jpry/.composer/bin/slic:0
    0.0006     398784   2. {closure:/Users/jpry/.composer/bin/slic:4-14}() /Users/jpry/.composer/bin/slic:14
    0.0011     424440   3. require_once('/Users/jpry/projects/slic/slic.php') /Users/jpry/.composer/bin/slic:13


Deprecated: StellarWP\Slic\check_status_or(): Implicitly marking parameter $else as nullable is deprecated, the explicit nullable type must be used instead in /Users/jpry/projects/slic/src/process.php on line 240

Call Stack:
    0.0001     398368   1. {main}() /Users/jpry/.composer/bin/slic:0
    0.0006     398784   2. {closure:/Users/jpry/.composer/bin/slic:4-14}() /Users/jpry/.composer/bin/slic:14
    0.0011     424440   3. require_once('/Users/jpry/projects/slic/slic.php') /Users/jpry/.composer/bin/slic:13
    0.0047     526440   4. require_once('/Users/jpry/projects/slic/src/utils.php') /Users/jpry/projects/slic/slic.php:6


Deprecated: StellarWP\Slic\ensure_wordpress_ready(): Implicitly marking parameter $version as nullable is deprecated, the explicit nullable type must be used instead in /Users/jpry/projects/slic/src/wordpress.php on line 154

Call Stack:
    0.0001     398368   1. {main}() /Users/jpry/.composer/bin/slic:0
    0.0006     398784   2. {closure:/Users/jpry/.composer/bin/slic:4-14}() /Users/jpry/.composer/bin/slic:14
    0.0011     424440   3. require_once('/Users/jpry/projects/slic/slic.php') /Users/jpry/.composer/bin/slic:13

slic version 1.9.1 - StellarWP local testing and development tool

Using the-events-calendar
```

This PR resolves these particular deprecated notices, and handles a few other small tweaks:

1. Replaces a ternary operator with `??`.
2. Import `Closure` instead of using the leading backslash
3. Remove an unused parameter (related to the last deprecation notice)

