### PR TITLE
v1.9.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.9.1] - 2025-05-14
+- Restored the `selenium/standaolone-crome` image to version `3.141.59` from `4.27.0-20241225` to ensure compatibility with older PHP driver versions.
+
+# [1.9.0] - 2025-01-20
+
 # [1.9.1] - 2025-04-15
 - Fixed - Better detection of ARM64 architecture in `is_arm64` function.
 

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.9.1';
+const CLI_VERSION = '1.9.2';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/src/slic.php
+++ b/src/slic.php
@@ -1679,7 +1679,7 @@ function setup_architecture_env() {
 		putenv( 'SLIC_CHROME_CONTAINER=seleniarm/standalone-chromium:4.20.0-20240427' );
 	} else {
 		putenv( 'SLIC_ARCHITECTURE=x86' );
-		putenv( 'SLIC_CHROME_CONTAINER=selenium/standalone-chrome:4.27.0-20241225' );
+		putenv( 'SLIC_CHROME_CONTAINER=selenium/standalone-chrome:3.141.59' );
 	}
 }
 


### PR DESCRIPTION
Restore the last working version of the `selenium/standalone-chrome`
container to ensure back-compatibility with drivers for older PHP
versions.
