### PR TITLE
set MySQL to 5.5.62 on PHP 7.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.10.0] - 2025-06-13
+- Breaking Minor Change - On PHP 7.4 MySQL version to 5.5.62 to align with WordPress minimum requirements. The version of MySQL can be overridden using a version of PHP that is not 7.4, by setting the `SLIC_DB_IMAGE` environment variable explicitly or by setting the `SLIC_DB_NO_MIN` environment variable to a non falsy value.
+
 # [1.9.2] - 2025-05-14
-- Restored the `selenium/standaolone-crome` image to version `3.141.59` from `4.27.0-20241225` to ensure compatibility with older PHP driver versions.
+- Fixed - Restored the `selenium/standaolone-crome` image to version `3.141.59` from `4.27.0-20241225` to ensure compatibility with older PHP driver versions.
 
 # [1.9.1] - 2025-04-15
 - Fixed - Better detection of ARM64 architecture in `is_arm64` function.

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -9,7 +9,9 @@ volumes:
 services:
 
   db:
-    image: mariadb:10.7.8
+    image: ${SLIC_DB_IMAGE:-mariadb:10.7.8}
+    # Not specifying a platform will ignore the setting and use the current platform.
+    platform: ${SLIC_DB_PLATFORM:-}
     networks:
       - slic
     ports:
@@ -120,7 +122,7 @@ services:
       - "${host:-host}:host-gateway"
 
   chrome:
-    image: ${SLIC_CHROME_CONTAINER:-selenium/standalone-chrome:3.141.59}
+    image: ${SLIC_CHROME_IMAGE:-selenium/standalone-chrome:3.141.59}
     networks:
       - slic
     depends_on:

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '1.9.2';
+const CLI_VERSION = '1.10.0';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
This change aligns `slic` with the minimum WordPress requirements of PHP 7.2 and MySQL 5.5.

[Link to WP requirements](https://wordpress.org/about/requirements/)

As a concession to the fact that `slic` is a  StellarWP tool, the minimum PHP version supported by it is PHP `7.4`.

This is treated like a minor breaking change since it's breaking by default, but can be controller setting either the `SLIC_DB_IMAGE` or `SLIC_DB_NO_MIN` environment variables.

