### PR TITLE
Normalized PHP versions before check

### DIFF
--- a/src/project.php
+++ b/src/project.php
@@ -174,7 +174,18 @@ function project_get_composer_php_version( $composer_json ) {
  */
 function project_apply_php_version( $slic_env_local, $slic_json, $composer_json ) {
 	$current_php_version = getenv( 'SLIC_PHP_VERSION' );
+
+	// Ensure the current PHP version is in `major.minor` format,  the format used by slic.
+	if ( $current_php_version ) {
+		$current_php_version = preg_replace( '/^(\d\.\d)\..+/', '$1', $current_php_version );
+	}
+
 	$project_php_version = $slic_json['phpVersion'] ?? project_get_composer_php_version( $composer_json );
+
+	// Ensure the project PHP version is in the `major.minor` format, the format used by slic.
+	if ( $project_php_version ) {
+		$project_php_version = preg_replace( '/^(\d\.\d)\..+/', '$1', $project_php_version );
+	}
 
 	$slic_env_php_version = $project_php_version;
 
@@ -184,6 +195,9 @@ function project_apply_php_version( $slic_env_local, $slic_json, $composer_json 
 	) {
 		$slic_env_php_version = trim( $matches[1] );
 	}
+
+	// Ensure the env PHP version is in the `major.minor` format, the format used by slic.
+	$slic_env_php_version = preg_replace( '/^(\d\.\d)\..+/', '$1', $slic_env_php_version );
 
 	if ( $project_php_version && $project_php_version !== $current_php_version ) {
 		slic_set_php_version( $project_php_version, false );


### PR DESCRIPTION
In the context of some commands, mainly the `slic use` one, the PHP
version set on the local `slic.json` file, the local `composer.json`
file or the `slic` run configuration file will be checked. The `slic`
tool uses and supports the definition of PHP versions in the
`major.minor` format that will map to its pre-built images. The PHP
version read from any of those files, though, could come in the
`major.minor.patch` format throwing the check off.

This fix normalizes any version `slic` reads from any of those files to
the `major.minor` format before running the checks and the potential
version switch.

Related: #215
