### PR TITLE
build(docker): source bullseye packages from the Debian archive

### DIFF
--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -38,6 +38,14 @@ RUN chmod a+rx /usr/local/bin/wp /usr/local/bin/install-php-extensions
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
+    # Debian 11 (bullseye) backs the PHP 7.3, 7.4 and 8.0 base images and left LTS on
+    # 2026-08-31. deb.debian.org still serves an expired bullseye-security index, which
+    # fails `apt-get update` outright, and has already purged that suite's pool, so
+    # anything resolved from it 404s. The archive carries every package this image needs
+    # and bullseye-security is not mirrored there, so point at the archive and drop it.
+    if [ "$(. /etc/os-release && echo "$VERSION_CODENAME")" = bullseye ]; then \
+        echo 'deb http://archive.debian.org/debian bullseye main' > /etc/apt/sources.list; \
+    fi && \
     apt-get update && \
     apt-get install -yqq --no-install-recommends \
         ca-certificates curl git zip unzip iproute2 \


### PR DESCRIPTION
Source bullseye packages from the Debian archive so the PHP 7.3, 7.4 and 8.0 images can build and install Playwright's browser dependencies again.

**Ticket: `NO_TASK`** — this came out of a CI failure with no ticket filed. Flagging rather than papering over.

## The problem

Reported from this failing run in `events-pro`: https://github.com/the-events-calendar/events-pro/actions/runs/34174543380/job/101915271022?pr=3087

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 5h 9min 23s).
Failed to install browsers
Error: Installation process exited with code: 100
```

Debian 11 (bullseye) left LTS on 2026-08-31. It backs the PHP 7.3, 7.4 and 8.0 base images, and two things break as a result:

1. **`slic playwright install` fails.** Its `--with-deps` step runs apt inside the container; `apt-get update` now exits 100 on the expired index and Playwright aborts before installing anything.
2. **The images can no longer be built.** `containers/slic/Dockerfile` chains `apt-get update && apt-get install` under `set -eou pipefail`, so the next publish of those three tags fails on the same exit 100. Not caused by the reported bug, but already armed.

There is a second layer to it: `deb.debian.org` still serves the stale bullseye-security *index* but has already **purged the pool**, so simply accepting the expired Release is not enough — packages then 404:

```
E: Failed to fetch .../libgbm1_20.3.5-1+deb11u1_arm64.deb  404  Not Found
E: Failed to fetch .../libexpat1_2.2.10-2+deb11u7_arm64.deb  404  Not Found
```

Hence pointing at `archive.debian.org` and dropping `bullseye-security` entirely, rather than an `Acquire::Check-Valid-Until` override.

## Reproducible flow

1. `docker run --rm --entrypoint bash ghcr.io/stellarwp/slic-php7.4:2.4.0 -c 'apt-get update; echo $?'`
   - **Before:** exits `100`, expired-Release error. **After:** exits `0`.
2. In a bullseye image with a project that has Playwright installed, run `node_modules/.bin/playwright install chromium --with-deps`.
   - **Before:** `Failed to install browsers / exited with code: 100`. **After:** browser, fonts and xvfb install.
3. `docker build --build-arg PHP_VERSION=7.4 containers/slic`
   - **Before:** the system-dependencies layer fails. **After:** it completes.

## Scope

Only bullseye. I checked the whole publish matrix:

```
php:7.3  bullseye apt=FAIL(100)     php:8.2  trixie apt=OK
php:7.4  bullseye apt=FAIL(100)     php:8.3  trixie apt=OK
php:8.0  bullseye apt=FAIL(100)     php:8.4  trixie apt=OK
php:8.1  trixie   apt=OK            php:8.5  trixie apt=OK
```

`containers/wordpress/Dockerfile` has no `apt-get`, so it is unaffected.

## Proof

Guard fires only where it should, both built with `--no-cache`:

```
7.4 sources.list: 1 archive.debian.org line   (build OK)
8.4 /etc/apt/sources.list: does not exist     (build OK, untouched)
```

The unmodified `playwright install chromium --with-deps` on a bullseye image built from this change:

```
Chrome Headless Shell 148.0.7778.96 downloaded to /root/.cache/ms-playwright/...
fonts-liberation         INSTALLED
fonts-noto-color-emoji   INSTALLED
xvfb                     INSTALLED
```

Package authentication is unchanged — apt still verifies the archive's signed `InRelease`:

```
GOODSIG 0E98404D386FA1D9 Debian Archive Automatic Signing Key (11/bullseye)
Got trusted VALIDSIG A7236886F3CCCAAD148A27F80E98404D386FA1D9
```

**Not verified:** a full end-to-end image build. It dies two layers later fetching `pecl/redis`, because `pecl.php.net` is unreachable from my machine (`curl` times out from the host too). Unrelated to this change, and CI should not hit it — but I have not watched a complete build go green, so that is worth a second pair of eyes on the first publish run.

## Trade-off worth a reviewer's attention

`bullseye-security` is not mirrored on `archive.debian.org` (it only goes up to buster) and its pool is gone from `deb.debian.org`, so those images no longer get Debian 11's final security updates. There is no source left to get them from — this is unavoidable rather than chosen. It is scoped to ephemeral test containers on PHP versions Debian itself no longer supports. Worth revisiting if bullseye-security is ever archived, or when these PHP versions are dropped.

## Considered and rejected

Making `--with-deps` fall back to a plain `playwright install` in `src/commands/playwright.php`. It is CLI-only, so it would fix jobs pinned to existing image tags immediately, which this PR cannot. But it silently drops the fonts and xvfb that `--with-deps` installs, degrading text rendering in screenshots and visual comparisons. If CI pins image tags, that fallback is still worth adding on top of this.

## Test coverage

None. This repo has no test suite — no `composer.json`, no `tests/`, and the only workflows are the two image publishers. Verification was done by running the failing commands in containers before and after, as shown above.

## AI usage

Claude Opus 5 investigated the failure, wrote the change, and verified it in containers on both bullseye and trixie images. An earlier draft of this fix removed `--with-deps` from `playwright.php` instead; QA showed that would have regressed font coverage, and it was dropped. A second draft also set `Acquire::Check-Valid-Until "false"` and kept `bullseye-updates`; both proved unnecessary and were cut before commit.

https://claude.ai/code/session_01HztxpxRTsncQ8rmHLR1oh4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container setup compatibility for Debian Bullseye-based environments by using archived package sources when installing system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->