### PR TITLE
Release 2.4.2 : Source bullseye packages from the Debian archive

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.4.2] - 2026-09-08
+- Fixed - The PHP 7.3, 7.4 and 8.0 images install system packages from the Debian archive, so they can be built and `slic playwright install` works again now that Debian 11 has left LTS.
+
 # [2.4.1] - 2026-08-18
 - Fixed - The object-cache drop-in filter now uses a serializable callback so PHPUnit suites can back up global state.
 

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -38,6 +38,14 @@ RUN chmod a+rx /usr/local/bin/wp /usr/local/bin/install-php-extensions
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
+    # Debian 11 (bullseye) backs the PHP 7.3, 7.4 and 8.0 base images and left LTS on
+    # 2026-08-31. deb.debian.org still serves an expired bullseye-security index, which
+    # fails `apt-get update` outright, and has already purged that suite's pool, so
+    # anything resolved from it 404s. The archive carries every package this image needs
+    # and bullseye-security is not mirrored there, so point at the archive and drop it.
+    if [ "$(. /etc/os-release && echo "$VERSION_CODENAME")" = bullseye ]; then \
+        echo 'deb http://archive.debian.org/debian bullseye main' > /etc/apt/sources.list; \
+    fi && \
     apt-get update && \
     apt-get install -yqq --no-install-recommends \
         ca-certificates curl git zip unzip iproute2 \

--- a/slic.php
+++ b/slic.php
@@ -54,7 +54,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '2.4.1';
+const CLI_VERSION = '2.4.2';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
Debian 11 left LTS on 2026-08-31. It backs the PHP 7.3, 7.4 and 8.0 images, and `deb.debian.org` now serves an expired `bullseye-security` index whose pool it has already purged. Those images source `main` from `archive.debian.org` instead and drop `bullseye-security`. Images on 8.1+ are trixie and untouched.

**Ticket: `NO_TASK`** — came out of a CI failure, none filed.

## Reproducing

Reported here: https://github.com/the-events-calendar/events-pro/actions/runs/34174543380/job/101915271022?pr=3087

1. `docker run --rm --entrypoint bash ghcr.io/stellarwp/slic-php7.4:2.4.0 -c 'apt-get update; echo $?'` — was `100`, now `0`.
2. `slic playwright install` in a bullseye target — was `Failed to install browsers / exited with code: 100`, now installs the browser, fonts and xvfb.
3. `docker build --build-arg PHP_VERSION=7.4 containers/slic` — the system-dependencies layer failed, now completes.

Accepting the expired index is not enough on its own; packages then 404, hence the archive.

## Review notes

- Those images no longer get Debian 11's final security updates. `bullseye-security` is not mirrored on the archive and its pool is gone, so there is no source left — unavoidable, and scoped to test containers on PHP versions Debian dropped.
- Package authentication is unchanged: apt still verifies the archive's signed `InRelease` against keys already in the image.
- No test coverage — this repo has no suite. Verified by running the failing commands in containers before and after, on both bullseye and trixie.
- A full image build was not observed end to end: it dies later on `pecl/redis`, unreachable from my machine. Unrelated, but worth watching the first publish run.

## Artifacts

```
7.4  guard fires, --no-cache build OK, sources.list -> archive.debian.org
8.4  guard skipped, --no-cache build OK, sources.list untouched
GOODSIG 0E98404D386FA1D9 Debian Archive Automatic Signing Key (11/bullseye)
```

Action passing with the current branch https://github.com/the-events-calendar/events-pro/actions/runs/34232389678/job/102081508008?pr=3087

---

AI was used to investigate and draft this change; I reviewed and tested it and own the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored successful image builds for PHP 7.3, 7.4, and 8.0 environments.
  * Fixed `slic playwright install` failures caused by unavailable Debian 11 package repositories.
  * Updated package installation to use the Debian archive for these legacy images.

* **Release**
  * Published version 2.4.2, dated September 8, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->